### PR TITLE
Sync loft type quantities with unit availability

### DIFF
--- a/public_html/wp-content/plugins/wp-loft-booking-plugin/includes/ajax/ajax-handlers.php
+++ b/public_html/wp-content/plugins/wp-loft-booking-plugin/includes/ajax/ajax-handlers.php
@@ -32,8 +32,9 @@ function wp_loft_booking_sync_units() {
 
     error_log("🚨 ENTERED wp_loft_booking_sync_units()");
 
-    $units_table = $wpdb->prefix . 'loft_units';
-    $keychains_table = $wpdb->prefix . 'loft_keychains';
+    $units_table      = $wpdb->prefix . 'loft_units';
+    $keychains_table  = $wpdb->prefix . 'loft_keychains';
+    $loft_types_table = $wpdb->prefix . 'loft_types';
 
     $token = get_option('butterflymx_access_token_v4');
     $environment = get_option('butterflymx_environment', 'sandbox');
@@ -167,6 +168,11 @@ function wp_loft_booking_sync_units() {
             }
         }
     }
+
+    // Update loft_types quantities
+    $wpdb->query($wpdb->prepare("UPDATE $loft_types_table SET quantity = %d WHERE LOWER(name) = %s", $summary['SIMPLE'], 'simple'));
+    $wpdb->query($wpdb->prepare("UPDATE $loft_types_table SET quantity = %d WHERE LOWER(name) = %s", $summary['DOUBLE'], 'double'));
+    $wpdb->query($wpdb->prepare("UPDATE $loft_types_table SET quantity = %d WHERE LOWER(name) = %s", $summary['PENTHOUSE'], 'penthouse'));
 
     // Update post_meta with only available counts
     update_post_meta(10773, 'nd_booking_meta_box_qnt', $summary['SIMPLE']);    // SIMPLE


### PR DESCRIPTION
## Summary
- track loft_types table quantities based on available units

## Testing
- `php -l public_html/wp-content/plugins/wp-loft-booking-plugin/includes/ajax/ajax-handlers.php`


------
https://chatgpt.com/codex/tasks/task_e_68955ad6deec8329bede12eb87f5621a