### PR TITLE
Allow guest ID image uploads in ND Booking

### DIFF
--- a/public_html/wp-content/plugins/nd-booking/inc/admin/orders/include/add.php
+++ b/public_html/wp-content/plugins/nd-booking/inc/admin/orders/include/add.php
@@ -68,7 +68,9 @@ function nd_booking_settings_menu_add_orders() { ?>
       $nd_booking_booking_form_payment_status,
       $nd_booking_booking_form_currency,
       $nd_booking_paypal_tx,
-      $nd_booking_booking_form_action_type
+      $nd_booking_booking_form_action_type,
+      '',
+      ''
 
     );
 

--- a/public_html/wp-content/plugins/nd-booking/inc/admin/orders/include/edit.php
+++ b/public_html/wp-content/plugins/nd-booking/inc/admin/orders/include/edit.php
@@ -113,6 +113,9 @@ if ( empty($nd_booking_orders) ) {
     //define action type
     $nd_booking_new_action_type = str_replace("_"," ",$nd_booking_order->action_type);
 
+    $guest_id_front = esc_url( get_post_meta( $nd_booking_order->id, 'guest_id_front', true ) );
+    $guest_id_back  = esc_url( get_post_meta( $nd_booking_order->id, 'guest_id_back', true ) );
+
 
     $nd_booking_result .= '
 
@@ -259,10 +262,16 @@ if ( empty($nd_booking_orders) ) {
             </div>
             
           
-          </div>
+          </div>';
 
-          
-          <div style="border: 1px solid #e5e5e5; box-shadow: 0 1px 1px rgba(0,0,0,.04);" class="nd_booking_section nd_booking_background_color_ffffff nd_booking_margin_top_20">
+          if ( current_user_can('manage_options') ) {
+            $nd_booking_result .= '<div class="nd_booking_section nd_booking_margin_top_20"><h3>'.__('Guest ID','nd-booking').'</h3>';
+            if ( $guest_id_front != '' ) { $nd_booking_result .= '<p><a href="'.$guest_id_front.'" target="_blank"><img src="'.$guest_id_front.'" width="150" /></a></p>'; }
+            if ( $guest_id_back != '' ) { $nd_booking_result .= '<p><a href="'.$guest_id_back.'" target="_blank"><img src="'.$guest_id_back.'" width="150" /></a></p>'; }
+            $nd_booking_result .= '</div>';
+          }
+
+          $nd_booking_result .= '<div style="border: 1px solid #e5e5e5; box-shadow: 0 1px 1px rgba(0,0,0,.04);" class="nd_booking_section nd_booking_background_color_ffffff nd_booking_margin_top_20">
             
             <div class="nd_booking_custom_tables nd_booking_section nd_booking_box_sizing_border_box nd_booking_padding_30">
 

--- a/public_html/wp-content/plugins/nd-booking/inc/functions/functions.php
+++ b/public_html/wp-content/plugins/nd-booking/inc/functions/functions.php
@@ -584,7 +584,9 @@ function nd_booking_add_booking_in_db(
   $nd_booking_paypal_payment_status,
   $nd_booking_paypal_currency,
   $nd_booking_paypal_tx,
-  $nd_booking_action_type
+  $nd_booking_action_type,
+  $guest_id_front = '',
+  $guest_id_back = ''
 
 ) {
 
@@ -639,14 +641,38 @@ function nd_booking_add_booking_in_db(
 
 			);
 
-			if ($nd_booking_add_booking){
+                        if ($nd_booking_add_booking){
 
-				//order added in db
-			
-				//hook
-	        	do_action('nd_booking_reservation_added_in_db',$nd_booking_id_post,$nd_booking_title_post,$nd_booking_date,$nd_booking_date_from,$nd_booking_date_to,$nd_booking_guests,$nd_booking_final_trip_price,$nd_booking_extra_services,$nd_booking_id_user,$nd_booking_user_first_name,$nd_booking_user_last_name,$nd_booking_paypal_email,$nd_booking_user_phone,$nd_booking_user_address,$nd_booking_user_city,$nd_booking_user_country,$nd_booking_user_message,$nd_booking_user_arrival,$nd_booking_user_coupon,$nd_booking_paypal_payment_status,$nd_booking_paypal_currency,$nd_booking_paypal_tx,$nd_booking_action_type);	
+                                $booking_id = $wpdb->insert_id;
 
-			}else{
+                                if ( $guest_id_front || $guest_id_back ) {
+                                        $upload_dir = wp_upload_dir();
+                                        $base_dir  = trailingslashit( $upload_dir['basedir'] ) . 'ids/' . $booking_id;
+                                        wp_mkdir_p( $base_dir );
+
+                                        if ( $guest_id_front && file_exists( $guest_id_front ) ) {
+                                                $dest_front = $base_dir . '/' . sanitize_file_name( basename( $guest_id_front ) );
+                                                @rename( $guest_id_front, $dest_front );
+                                                $front_url = trailingslashit( $upload_dir['baseurl'] ) . 'ids/' . $booking_id . '/' . basename( $dest_front );
+                                                add_post_meta( $booking_id, 'guest_id_front', $front_url );
+                                        }
+
+                                        if ( $guest_id_back && file_exists( $guest_id_back ) ) {
+                                                $dest_back = $base_dir . '/' . sanitize_file_name( basename( $guest_id_back ) );
+                                                @rename( $guest_id_back, $dest_back );
+                                                $back_url = trailingslashit( $upload_dir['baseurl'] ) . 'ids/' . $booking_id . '/' . basename( $dest_back );
+                                                add_post_meta( $booking_id, 'guest_id_back', $back_url );
+                                        }
+                                }
+
+                                //order added in db
+
+                                //hook
+                        do_action('nd_booking_reservation_added_in_db',$nd_booking_id_post,$nd_booking_title_post,$nd_booking_date,$nd_booking_date_from,$nd_booking_date_to,$nd_booking_guests,$nd_booking_final_trip_price,$nd_booking_extra_services,$nd_booking_id_user,$nd_booking_user_first_name,$nd_booking_user_last_name,$nd_booking_paypal_email,$nd_booking_user_phone,$nd_booking_user_address,$nd_booking_user_city,$nd_booking_user_country,$nd_booking_user_message,$nd_booking_user_arrival,$nd_booking_user_coupon,$nd_booking_paypal_payment_status,$nd_booking_paypal_currency,$nd_booking_paypal_tx,$nd_booking_action_type);
+
+                                return $booking_id;
+
+                        }else{
 
 			$wpdb->show_errors();
 			$wpdb->print_error();

--- a/public_html/wp-content/plugins/nd-booking/inc/shortcodes/include/booking/nd_booking_booking_right_content.php
+++ b/public_html/wp-content/plugins/nd-booking/inc/shortcodes/include/booking/nd_booking_booking_right_content.php
@@ -10,7 +10,7 @@ $nd_booking_shortcode_right_content = '
   <h1>'.__('Add Your Informations','nd-booking').' :</h1>
   <div class="nd_booking_section nd_booking_height_30"></div>
 
-  <form method="post" action="'.nd_booking_checkout_page().'">
+  <form method="post" enctype="multipart/form-data" action="'.nd_booking_checkout_page().'">
       
       <input type="hidden" id="nd_booking_form_booking_arrive" name="nd_booking_form_booking_arrive" value="1">
       <input type="hidden" id="nd_booking_booking_form_final_price" name="nd_booking_booking_form_final_price" value="'.$nd_booking_trip_price.'">
@@ -66,6 +66,19 @@ $nd_booking_shortcode_right_content = '
           <input class="nd_booking_section" id="nd_booking_booking_form_zip" name="nd_booking_booking_form_zip" type="text" >
       </div>
       <div class="nd_booking_section nd_booking_height_20"></div>
+
+      <div class="nd_booking_width_50_percentage nd_booking_width_100_percentage_all_iphone nd_booking_padding_0_all_iphone nd_booking_padding_right_10 nd_booking_box_sizing_border_box nd_booking_float_left">
+          <p>'.__('Guest ID Front','nd-booking').'</p>
+          <div class="nicdark_section nicdark_height_5"></div>
+          <input class="nd_booking_section" type="file" name="guest_id_front" accept="image/*" />
+      </div>
+      <div class="nd_booking_width_50_percentage nd_booking_width_100_percentage_all_iphone nd_booking_padding_0_all_iphone nd_booking_padding_left_10 nd_booking_box_sizing_border_box nd_booking_float_left">
+          <p>'.__('Guest ID Back','nd-booking').'</p>
+          <div class="nicdark_section nicdark_height_5"></div>
+          <input class="nd_booking_section" type="file" name="guest_id_back" accept="image/*" />
+      </div>
+      <div class="nd_booking_section nd_booking_height_20"></div>
+
       <div id="nd_booking_booking_form_requests_container"  class="nd_booking_width_100_percentage nd_booking_box_sizing_border_box nd_booking_float_left">
           <p>'.__('Requests','nd-booking').'</p>
           <div class="nicdark_section nicdark_height_5"></div>

--- a/public_html/wp-content/plugins/nd-booking/inc/shortcodes/include/checkout/nd_booking_checkout_payment_options.php
+++ b/public_html/wp-content/plugins/nd-booking/inc/shortcodes/include/checkout/nd_booking_checkout_payment_options.php
@@ -105,6 +105,8 @@ $nd_booking_shortcode_right_content .= '
                 <input type="hidden" id="nd_booking_checkout_form_requets" name="nd_booking_checkout_form_requets" value="'.$nd_booking_booking_form_requests.'">
                 <input type="hidden" id="nd_booking_checkout_form_arrival" name="nd_booking_checkout_form_arrival" value="'.$nd_booking_booking_form_arrival.'">
                 <input type="hidden" id="nd_booking_checkout_form_coupon" name="nd_booking_checkout_form_coupon" value="'.$nd_booking_booking_form_coupon.'">
+                <input type="hidden" id="nd_booking_checkout_form_guest_id_front" name="nd_booking_checkout_form_guest_id_front" value="'.$nd_booking_guest_id_front.'">
+                <input type="hidden" id="nd_booking_checkout_form_guest_id_back" name="nd_booking_checkout_form_guest_id_back" value="'.$nd_booking_guest_id_back.'">
                 <input type="hidden" id="nd_booking_checkout_form_term" name="nd_booking_checkout_form_term" value="'.$nd_booking_booking_form_term.'">
                 <input type="hidden" id="nd_booking_booking_form_services" name="nd_booking_booking_form_services" value="'.$nd_booking_booking_form_services.'">
 
@@ -147,6 +149,8 @@ $nd_booking_shortcode_right_content .= '
                 <input type="hidden" id="nd_booking_checkout_form_requets" name="nd_booking_checkout_form_requets" value="'.$nd_booking_booking_form_requests.'">
                 <input type="hidden" id="nd_booking_checkout_form_arrival" name="nd_booking_checkout_form_arrival" value="'.$nd_booking_booking_form_arrival.'">
                 <input type="hidden" id="nd_booking_checkout_form_coupon" name="nd_booking_checkout_form_coupon" value="'.$nd_booking_booking_form_coupon.'">
+                <input type="hidden" id="nd_booking_checkout_form_guest_id_front" name="nd_booking_checkout_form_guest_id_front" value="'.$nd_booking_guest_id_front.'">
+                <input type="hidden" id="nd_booking_checkout_form_guest_id_back" name="nd_booking_checkout_form_guest_id_back" value="'.$nd_booking_guest_id_back.'">
                 <input type="hidden" id="nd_booking_checkout_form_term" name="nd_booking_checkout_form_term" value="'.$nd_booking_booking_form_term.'">
                 <input type="hidden" id="nd_booking_booking_form_services" name="nd_booking_booking_form_services" value="'.$nd_booking_booking_form_services.'">
 
@@ -189,6 +193,8 @@ $nd_booking_shortcode_right_content .= '
                 <input type="hidden" id="nd_booking_checkout_form_requets" name="nd_booking_checkout_form_requets" value="'.$nd_booking_booking_form_requests.'">
                 <input type="hidden" id="nd_booking_checkout_form_arrival" name="nd_booking_checkout_form_arrival" value="'.$nd_booking_booking_form_arrival.'">
                 <input type="hidden" id="nd_booking_checkout_form_coupon" name="nd_booking_checkout_form_coupon" value="'.$nd_booking_booking_form_coupon.'">
+                <input type="hidden" id="nd_booking_checkout_form_guest_id_front" name="nd_booking_checkout_form_guest_id_front" value="'.$nd_booking_guest_id_front.'">
+                <input type="hidden" id="nd_booking_checkout_form_guest_id_back" name="nd_booking_checkout_form_guest_id_back" value="'.$nd_booking_guest_id_back.'">
                 <input type="hidden" id="nd_booking_checkout_form_term" name="nd_booking_checkout_form_term" value="'.$nd_booking_booking_form_term.'">
                 <input type="hidden" id="nd_booking_booking_form_services" name="nd_booking_booking_form_services" value="'.$nd_booking_booking_form_services.'">
 
@@ -238,6 +244,8 @@ $nd_booking_shortcode_right_content .= '
                 <input type="hidden" id="nd_booking_checkout_form_requets" name="nd_booking_checkout_form_requets" value="'.$nd_booking_booking_form_requests.'">
                 <input type="hidden" id="nd_booking_checkout_form_arrival" name="nd_booking_checkout_form_arrival" value="'.$nd_booking_booking_form_arrival.'">
                 <input type="hidden" id="nd_booking_checkout_form_coupon" name="nd_booking_checkout_form_coupon" value="'.$nd_booking_booking_form_coupon.'">
+                <input type="hidden" id="nd_booking_checkout_form_guest_id_front" name="nd_booking_checkout_form_guest_id_front" value="'.$nd_booking_guest_id_front.'">
+                <input type="hidden" id="nd_booking_checkout_form_guest_id_back" name="nd_booking_checkout_form_guest_id_back" value="'.$nd_booking_guest_id_back.'">
                 <input type="hidden" id="nd_booking_checkout_form_term" name="nd_booking_checkout_form_term" value="'.$nd_booking_booking_form_term.'">
                 <input type="hidden" id="nd_booking_booking_form_services" name="nd_booking_booking_form_services" value="'.$nd_booking_booking_form_services.'">
                 <input type="hidden" id="nd_booking_booking_form_action_type" name="nd_booking_booking_form_action_type" value="stripe">

--- a/public_html/wp-content/plugins/nd-booking/inc/shortcodes/nd_booking_checkout.php
+++ b/public_html/wp-content/plugins/nd-booking/inc/shortcodes/nd_booking_checkout.php
@@ -34,6 +34,37 @@ function nd_booking_shortcode_checkout() {
         $nd_booking_booking_form_post_title = sanitize_text_field($_POST['nd_booking_booking_form_post_title']);
         $nd_booking_booking_form_services = sanitize_text_field($_POST['nd_booking_booking_checkbox_services_id']);
 
+        $nd_booking_guest_id_front = '';
+        $nd_booking_guest_id_back = '';
+
+        if ( ! empty( $_FILES['guest_id_front']['name'] ) || ! empty( $_FILES['guest_id_back']['name'] ) ) {
+            if ( ! function_exists( 'wp_handle_upload' ) ) {
+                require_once ABSPATH . 'wp-admin/includes/file.php';
+            }
+            $upload_overrides = [
+                'test_form' => false,
+                'mimes'     => [
+                    'jpg|jpeg|jpe' => 'image/jpeg',
+                    'png'          => 'image/png',
+                ],
+            ];
+
+            $max_size = 2 * 1024 * 1024; // 2MB
+
+            if ( ! empty( $_FILES['guest_id_front']['name'] ) && $_FILES['guest_id_front']['size'] <= $max_size ) {
+                $front = wp_handle_upload( $_FILES['guest_id_front'], $upload_overrides );
+                if ( empty( $front['error'] ) ) {
+                    $nd_booking_guest_id_front = $front['file'];
+                }
+            }
+            if ( ! empty( $_FILES['guest_id_back']['name'] ) && $_FILES['guest_id_back']['size'] <= $max_size ) {
+                $back = wp_handle_upload( $_FILES['guest_id_back'], $upload_overrides );
+                if ( empty( $back['error'] ) ) {
+                    $nd_booking_guest_id_back = $back['file'];
+                }
+            }
+        }
+
         //ids
         $nd_booking_booking_form_post_id = sanitize_text_field($_POST['nd_booking_booking_form_post_id']);
         $nd_booking_ids_array = explode('-', $nd_booking_booking_form_post_id ); 
@@ -73,9 +104,9 @@ function nd_booking_shortcode_checkout() {
     //START PAYMENT ON CHECKOUT PAGE
     }elseif ( $nd_booking_form_checkout_arrive == 1 OR isset($_GET['tx']) OR $nd_booking_form_checkout_arrive == 2 ) {
 
+        $nd_booking_guest_id_front = '';
+        $nd_booking_guest_id_back = '';
 
-        
-        
         //START BUILT VARIABLES DEPENDING ON PAYMENT METHODS
         if ( $nd_booking_form_checkout_arrive == 1 ) {
 
@@ -112,6 +143,8 @@ function nd_booking_shortcode_checkout() {
             $nd_booking_booking_form_services = sanitize_text_field($_POST['nd_booking_booking_form_services']);
             $nd_booking_booking_form_action_type = sanitize_text_field($_POST['nd_booking_booking_form_action_type']);
             $nd_booking_booking_form_payment_status = sanitize_text_field($_POST['nd_booking_booking_form_payment_status']);
+            $nd_booking_guest_id_front = sanitize_text_field($_POST['nd_booking_checkout_form_guest_id_front']);
+            $nd_booking_guest_id_back = sanitize_text_field($_POST['nd_booking_checkout_form_guest_id_back']);
 
             //ids
             $nd_booking_checkout_form_post_id = sanitize_text_field($_POST['nd_booking_checkout_form_post_id']);
@@ -151,6 +184,8 @@ function nd_booking_shortcode_checkout() {
             $nd_booking_booking_form_services = sanitize_text_field($_POST['nd_booking_booking_form_services']);
             $nd_booking_booking_form_action_type = sanitize_text_field($_POST['nd_booking_booking_form_action_type']);
             $nd_booking_booking_form_payment_status = sanitize_text_field($_POST['nd_booking_booking_form_payment_status']);
+            $nd_booking_guest_id_front = sanitize_text_field($_POST['nd_booking_checkout_form_guest_id_front']);
+            $nd_booking_guest_id_back = sanitize_text_field($_POST['nd_booking_checkout_form_guest_id_back']);
 
             //ids
             $nd_booking_checkout_form_post_id = sanitize_text_field($_POST['nd_booking_checkout_form_post_id']);
@@ -471,7 +506,7 @@ function nd_booking_shortcode_checkout() {
         //END check if user is logged
 
 
-        nd_booking_add_booking_in_db(
+        $nd_booking_booking_id = nd_booking_add_booking_in_db(
   
           $nd_booking_id_room,
           get_the_title($nd_booking_id_room),
@@ -495,7 +530,9 @@ function nd_booking_shortcode_checkout() {
           $nd_booking_booking_form_payment_status,
           $nd_booking_booking_form_currency,
           $nd_booking_paypal_tx,
-          $nd_booking_booking_form_action_type
+          $nd_booking_booking_form_action_type,
+          $nd_booking_guest_id_front,
+          $nd_booking_guest_id_back
 
         );
 

--- a/public_html/wp-content/plugins/nd-booking/inc/shortcodes/nd_booking_search_result.php
+++ b/public_html/wp-content/plugins/nd-booking/inc/shortcodes/nd_booking_search_result.php
@@ -145,7 +145,9 @@ function nd_booking_woo_thankyou_content( $order_id ) {
             $nd_booking_booking_form_payment_status,
             $nd_booking_booking_form_currency,
             $nd_booking_paypal_tx,
-            $nd_booking_booking_form_action_type
+            $nd_booking_booking_form_action_type,
+            '',
+            ''
         );
         
     }


### PR DESCRIPTION
## Summary
- add guest ID front/back file fields to booking form
- process uploads, store under booking-specific folder, and save meta links
- expose stored ID images in admin order details

## Testing
- `php -l public_html/wp-content/plugins/nd-booking/inc/shortcodes/include/booking/nd_booking_booking_right_content.php`
- `php -l public_html/wp-content/plugins/nd-booking/inc/shortcodes/nd_booking_checkout.php`
- `php -l public_html/wp-content/plugins/nd-booking/inc/shortcodes/include/checkout/nd_booking_checkout_payment_options.php`
- `php -l public_html/wp-content/plugins/nd-booking/inc/functions/functions.php`
- `php -l public_html/wp-content/plugins/nd-booking/inc/shortcodes/nd_booking_search_result.php`
- `php -l public_html/wp-content/plugins/nd-booking/inc/admin/orders/include/add.php`
- `php -l public_html/wp-content/plugins/nd-booking/inc/admin/orders/include/edit.php`


------
https://chatgpt.com/codex/tasks/task_e_6897882fbd088329804a8323659f80c2