### PR TITLE
Capture and store guest ID metadata

### DIFF
--- a/public_html/wp-content/plugins/nd-booking/inc/admin/orders/include/edit.php
+++ b/public_html/wp-content/plugins/nd-booking/inc/admin/orders/include/edit.php
@@ -113,8 +113,10 @@ if ( empty($nd_booking_orders) ) {
     //define action type
     $nd_booking_new_action_type = str_replace("_"," ",$nd_booking_order->action_type);
 
-    $guest_id_front = esc_url( get_post_meta( $nd_booking_order->id, 'guest_id_front', true ) );
-    $guest_id_back  = esc_url( get_post_meta( $nd_booking_order->id, 'guest_id_back', true ) );
+    $guest_id_front  = esc_url( get_post_meta( $nd_booking_order->id, 'guest_id_front', true ) );
+    $guest_id_back   = esc_url( get_post_meta( $nd_booking_order->id, 'guest_id_back', true ) );
+    $guest_id_number = sanitize_text_field( get_post_meta( $nd_booking_order->id, 'guest_id_number', true ) );
+    $guest_id_type   = sanitize_text_field( get_post_meta( $nd_booking_order->id, 'guest_id_type', true ) );
 
 
     $nd_booking_result .= '
@@ -266,6 +268,8 @@ if ( empty($nd_booking_orders) ) {
 
           if ( current_user_can('manage_options') ) {
             $nd_booking_result .= '<div class="nd_booking_section nd_booking_margin_top_20"><h3>'.__('Guest ID','nd-booking').'</h3>';
+            if ( $guest_id_number != '' ) { $nd_booking_result .= '<p>'.__('ID Number','nd-booking').': '.esc_html($guest_id_number).'</p>'; }
+            if ( $guest_id_type != '' ) { $nd_booking_result .= '<p>'.__('ID Type','nd-booking').': '.esc_html($guest_id_type).'</p>'; }
             if ( $guest_id_front != '' ) { $nd_booking_result .= '<p><a href="'.$guest_id_front.'" target="_blank"><img src="'.$guest_id_front.'" width="150" /></a></p>'; }
             if ( $guest_id_back != '' ) { $nd_booking_result .= '<p><a href="'.$guest_id_back.'" target="_blank"><img src="'.$guest_id_back.'" width="150" /></a></p>'; }
             $nd_booking_result .= '</div>';

--- a/public_html/wp-content/plugins/nd-booking/inc/shortcodes/include/checkout/nd_booking_checkout_payment_options.php
+++ b/public_html/wp-content/plugins/nd-booking/inc/shortcodes/include/checkout/nd_booking_checkout_payment_options.php
@@ -107,6 +107,8 @@ $nd_booking_shortcode_right_content .= '
                 <input type="hidden" id="nd_booking_checkout_form_coupon" name="nd_booking_checkout_form_coupon" value="'.$nd_booking_booking_form_coupon.'">
                 <input type="hidden" id="nd_booking_checkout_form_guest_id_front" name="nd_booking_checkout_form_guest_id_front" value="'.$nd_booking_guest_id_front_token.'">
                 <input type="hidden" id="nd_booking_checkout_form_guest_id_back" name="nd_booking_checkout_form_guest_id_back" value="'.$nd_booking_guest_id_back_token.'">
+                <input type="hidden" id="nd_booking_checkout_form_guest_id_number" name="nd_booking_checkout_form_guest_id_number" value="'.$nd_booking_guest_id_number.'">
+                <input type="hidden" id="nd_booking_checkout_form_guest_id_type" name="nd_booking_checkout_form_guest_id_type" value="'.$nd_booking_guest_id_type.'">
                 <input type="hidden" id="nd_booking_checkout_form_term" name="nd_booking_checkout_form_term" value="'.$nd_booking_booking_form_term.'">
                 <input type="hidden" id="nd_booking_booking_form_services" name="nd_booking_booking_form_services" value="'.$nd_booking_booking_form_services.'">
 
@@ -151,6 +153,8 @@ $nd_booking_shortcode_right_content .= '
                 <input type="hidden" id="nd_booking_checkout_form_coupon" name="nd_booking_checkout_form_coupon" value="'.$nd_booking_booking_form_coupon.'">
                 <input type="hidden" id="nd_booking_checkout_form_guest_id_front" name="nd_booking_checkout_form_guest_id_front" value="'.$nd_booking_guest_id_front_token.'">
                 <input type="hidden" id="nd_booking_checkout_form_guest_id_back" name="nd_booking_checkout_form_guest_id_back" value="'.$nd_booking_guest_id_back_token.'">
+                <input type="hidden" id="nd_booking_checkout_form_guest_id_number" name="nd_booking_checkout_form_guest_id_number" value="'.$nd_booking_guest_id_number.'">
+                <input type="hidden" id="nd_booking_checkout_form_guest_id_type" name="nd_booking_checkout_form_guest_id_type" value="'.$nd_booking_guest_id_type.'">
                 <input type="hidden" id="nd_booking_checkout_form_term" name="nd_booking_checkout_form_term" value="'.$nd_booking_booking_form_term.'">
                 <input type="hidden" id="nd_booking_booking_form_services" name="nd_booking_booking_form_services" value="'.$nd_booking_booking_form_services.'">
 
@@ -195,6 +199,8 @@ $nd_booking_shortcode_right_content .= '
                 <input type="hidden" id="nd_booking_checkout_form_coupon" name="nd_booking_checkout_form_coupon" value="'.$nd_booking_booking_form_coupon.'">
                 <input type="hidden" id="nd_booking_checkout_form_guest_id_front" name="nd_booking_checkout_form_guest_id_front" value="'.$nd_booking_guest_id_front_token.'">
                 <input type="hidden" id="nd_booking_checkout_form_guest_id_back" name="nd_booking_checkout_form_guest_id_back" value="'.$nd_booking_guest_id_back_token.'">
+                <input type="hidden" id="nd_booking_checkout_form_guest_id_number" name="nd_booking_checkout_form_guest_id_number" value="'.$nd_booking_guest_id_number.'">
+                <input type="hidden" id="nd_booking_checkout_form_guest_id_type" name="nd_booking_checkout_form_guest_id_type" value="'.$nd_booking_guest_id_type.'">
                 <input type="hidden" id="nd_booking_checkout_form_term" name="nd_booking_checkout_form_term" value="'.$nd_booking_booking_form_term.'">
                 <input type="hidden" id="nd_booking_booking_form_services" name="nd_booking_booking_form_services" value="'.$nd_booking_booking_form_services.'">
 
@@ -246,6 +252,8 @@ $nd_booking_shortcode_right_content .= '
                 <input type="hidden" id="nd_booking_checkout_form_coupon" name="nd_booking_checkout_form_coupon" value="'.$nd_booking_booking_form_coupon.'">
                 <input type="hidden" id="nd_booking_checkout_form_guest_id_front" name="nd_booking_checkout_form_guest_id_front" value="'.$nd_booking_guest_id_front_token.'">
                 <input type="hidden" id="nd_booking_checkout_form_guest_id_back" name="nd_booking_checkout_form_guest_id_back" value="'.$nd_booking_guest_id_back_token.'">
+                <input type="hidden" id="nd_booking_checkout_form_guest_id_number" name="nd_booking_checkout_form_guest_id_number" value="'.$nd_booking_guest_id_number.'">
+                <input type="hidden" id="nd_booking_checkout_form_guest_id_type" name="nd_booking_checkout_form_guest_id_type" value="'.$nd_booking_guest_id_type.'">
                 <input type="hidden" id="nd_booking_checkout_form_term" name="nd_booking_checkout_form_term" value="'.$nd_booking_booking_form_term.'">
                 <input type="hidden" id="nd_booking_booking_form_services" name="nd_booking_booking_form_services" value="'.$nd_booking_booking_form_services.'">
                 <input type="hidden" id="nd_booking_booking_form_action_type" name="nd_booking_booking_form_action_type" value="stripe">

--- a/public_html/wp-content/plugins/nd-booking/inc/shortcodes/nd_booking_checkout.php
+++ b/public_html/wp-content/plugins/nd-booking/inc/shortcodes/nd_booking_checkout.php
@@ -55,6 +55,17 @@ function nd_booking_shortcode_checkout() {
         $nd_booking_booking_form_post_title = sanitize_text_field($_POST['nd_booking_booking_form_post_title']);
         $nd_booking_booking_form_services = sanitize_text_field($_POST['nd_booking_booking_checkbox_services_id']);
 
+        if ( isset( $_POST['guest_id_number'] ) ) {
+            $nd_booking_guest_id_number = sanitize_text_field( $_POST['guest_id_number'] );
+        } else {
+            $nd_booking_guest_id_number = '';
+        }
+        if ( isset( $_POST['guest_id_type'] ) ) {
+            $nd_booking_guest_id_type = sanitize_text_field( $_POST['guest_id_type'] );
+        } else {
+            $nd_booking_guest_id_type = '';
+        }
+
         $nd_booking_guest_id_front = '';
         $nd_booking_guest_id_back = '';
 
@@ -178,11 +189,13 @@ function nd_booking_shortcode_checkout() {
             $nd_booking_booking_form_term = sanitize_text_field($_POST['nd_booking_checkout_form_term']);
             $nd_booking_booking_form_services = sanitize_text_field($_POST['nd_booking_booking_form_services']);
             $nd_booking_booking_form_action_type = sanitize_text_field($_POST['nd_booking_booking_form_action_type']);
-            $nd_booking_booking_form_payment_status = sanitize_text_field($_POST['nd_booking_booking_form_payment_status']);
-            $front_token = sanitize_text_field($_POST['nd_booking_checkout_form_guest_id_front']);
-            $back_token  = sanitize_text_field($_POST['nd_booking_checkout_form_guest_id_back']);
-            $nd_booking_guest_id_front = nd_booking_get_upload_path_from_token( $front_token );
-            $nd_booking_guest_id_back  = nd_booking_get_upload_path_from_token( $back_token );
+              $nd_booking_booking_form_payment_status = sanitize_text_field($_POST['nd_booking_booking_form_payment_status']);
+              $nd_booking_guest_id_number = sanitize_text_field($_POST['nd_booking_checkout_form_guest_id_number']);
+              $nd_booking_guest_id_type   = sanitize_text_field($_POST['nd_booking_checkout_form_guest_id_type']);
+              $front_token = sanitize_text_field($_POST['nd_booking_checkout_form_guest_id_front']);
+              $back_token  = sanitize_text_field($_POST['nd_booking_checkout_form_guest_id_back']);
+              $nd_booking_guest_id_front = nd_booking_get_upload_path_from_token( $front_token );
+              $nd_booking_guest_id_back  = nd_booking_get_upload_path_from_token( $back_token );
 
             //ids
             $nd_booking_checkout_form_post_id = sanitize_text_field($_POST['nd_booking_checkout_form_post_id']);
@@ -221,11 +234,13 @@ function nd_booking_shortcode_checkout() {
             $nd_booking_booking_form_term = sanitize_text_field($_POST['nd_booking_checkout_form_term']);
             $nd_booking_booking_form_services = sanitize_text_field($_POST['nd_booking_booking_form_services']);
             $nd_booking_booking_form_action_type = sanitize_text_field($_POST['nd_booking_booking_form_action_type']);
-            $nd_booking_booking_form_payment_status = sanitize_text_field($_POST['nd_booking_booking_form_payment_status']);
-            $front_token = sanitize_text_field($_POST['nd_booking_checkout_form_guest_id_front']);
-            $back_token  = sanitize_text_field($_POST['nd_booking_checkout_form_guest_id_back']);
-            $nd_booking_guest_id_front = nd_booking_get_upload_path_from_token( $front_token );
-            $nd_booking_guest_id_back  = nd_booking_get_upload_path_from_token( $back_token );
+              $nd_booking_booking_form_payment_status = sanitize_text_field($_POST['nd_booking_booking_form_payment_status']);
+              $nd_booking_guest_id_number = sanitize_text_field($_POST['nd_booking_checkout_form_guest_id_number']);
+              $nd_booking_guest_id_type   = sanitize_text_field($_POST['nd_booking_checkout_form_guest_id_type']);
+              $front_token = sanitize_text_field($_POST['nd_booking_checkout_form_guest_id_front']);
+              $back_token  = sanitize_text_field($_POST['nd_booking_checkout_form_guest_id_back']);
+              $nd_booking_guest_id_front = nd_booking_get_upload_path_from_token( $front_token );
+              $nd_booking_guest_id_back  = nd_booking_get_upload_path_from_token( $back_token );
 
             //ids
             $nd_booking_checkout_form_post_id = sanitize_text_field($_POST['nd_booking_checkout_form_post_id']);
@@ -575,6 +590,11 @@ function nd_booking_shortcode_checkout() {
           $nd_booking_guest_id_back
 
         );
+
+        update_post_meta( $nd_booking_booking_id, 'guest_id_front', esc_url_raw( $nd_booking_guest_id_front ) );
+        update_post_meta( $nd_booking_booking_id, 'guest_id_back', esc_url_raw( $nd_booking_guest_id_back ) );
+        update_post_meta( $nd_booking_booking_id, 'guest_id_number', sanitize_text_field( $nd_booking_guest_id_number ) );
+        update_post_meta( $nd_booking_booking_id, 'guest_id_type', sanitize_text_field( $nd_booking_guest_id_type ) );
 
         if (function_exists('add_booking_to_google_calendar')) {
             $args = [


### PR DESCRIPTION
## Summary
- collect guest ID number and type during checkout
- persist guest ID metadata on booking records and expose in admin

## Testing
- `php -l public_html/wp-content/plugins/nd-booking/inc/shortcodes/nd_booking_checkout.php`
- `php -l public_html/wp-content/plugins/nd-booking/inc/shortcodes/include/checkout/nd_booking_checkout_payment_options.php`
- `php -l public_html/wp-content/plugins/nd-booking/inc/admin/orders/include/edit.php`


------
https://chatgpt.com/codex/tasks/task_e_6898853d0e58832984c9775953b85247