### PR TITLE
Filter units using active keychains

### DIFF
--- a/public_html/wp-content/plugins/wp-loft-booking-plugin/includes/ajax/ajax-handlers.php
+++ b/public_html/wp-content/plugins/wp-loft-booking-plugin/includes/ajax/ajax-handlers.php
@@ -12,14 +12,17 @@ function wp_loft_booking_get_units() {
     global $wpdb;
     $branch_id = intval($_POST['branch_id']);
 
-    // Fetch units with no active bookings for the selected branch
-    $units = $wpdb->get_results($wpdb->prepare("
-        SELECT u.id, u.unit_name 
-        FROM {$wpdb->prefix}loft_units u
-        LEFT JOIN {$wpdb->prefix}loft_virtual_keys vk ON u.id = vk.unit_id
-        WHERE u.branch_id = %d
-        AND (vk.expiration_date IS NULL OR vk.expiration_date < NOW())
-    ", $branch_id));
+    // Fetch units with no active keychains for the selected branch
+    $units = $wpdb->get_results($wpdb->prepare(
+        "SELECT u.id, u.unit_name
+         FROM {$wpdb->prefix}loft_units u
+         LEFT JOIN {$wpdb->prefix}loft_keychains kc
+           ON kc.unit_id = u.id AND kc.valid_until >= NOW()
+         WHERE u.branch_id = %d
+           AND kc.unit_id IS NULL
+           AND u.status = 'available'",
+        $branch_id
+    ));
 
     wp_send_json($units);
 }


### PR DESCRIPTION
## Summary
- Switch wp_loft_booking_get_units to join loft_keychains with validity filtering
- Only return units with no active keychains and status `available`

## Testing
- `php -l public_html/wp-content/plugins/wp-loft-booking-plugin/includes/ajax/ajax-handlers.php`


------
https://chatgpt.com/codex/tasks/task_e_689b4ebad03c8329bae1763dac1a3e6a