### PR TITLE
Handle penthouse units without parentheses

### DIFF
--- a/public_html/wp-content/plugins/wp-loft-booking-plugin/includes/ajax/ajax-handlers.php
+++ b/public_html/wp-content/plugins/wp-loft-booking-plugin/includes/ajax/ajax-handlers.php
@@ -248,7 +248,7 @@ function test_room_counts_from_loft_units() {
             $double++;
         }
 
-        if (stripos($title, '(PENTHOUSE)') !== false && $status === 'available') {
+        if (stripos($title, 'PENTHOUSE') !== false && $status === 'available') {
             $penthouse++;
         }
     }
@@ -284,7 +284,7 @@ function update_room_quantities_after_loft_sync() {
             $simple_count++;
         } elseif (preg_match('/\( *DOUBLE *\)/i', $title)) {
             $double_count++;
-        } elseif (preg_match('/\( *PENTHOUSE *\)/i', $title)) {
+        } elseif (preg_match('/PENTHOUSE/i', $title)) {
             $penthouse_count++;
         }
     }

--- a/public_html/wp-content/plugins/wp-loft-booking-plugin/includes/shortcodes/display-results.php
+++ b/public_html/wp-content/plugins/wp-loft-booking-plugin/includes/shortcodes/display-results.php
@@ -56,7 +56,7 @@ function custom_booking_search_results() {
                 CASE \
                     WHEN LOWER(unit_name) LIKE '%(simple)%' THEN 'simple' \
                     WHEN LOWER(unit_name) LIKE '%(double)%' THEN 'double' \
-                    WHEN LOWER(unit_name) LIKE '%(penthouse)%' THEN 'penthouse' \
+                    WHEN LOWER(unit_name) LIKE '%penthouse%' THEN 'penthouse' \
                 END AS type, \
                 COUNT(*) AS cnt \
             FROM {$wpdb->prefix}loft_units \


### PR DESCRIPTION
## Summary
- Detect penthouse units whether or not they include parentheses when counting availability and updating quantities
- Ensure shortcode query counts penthouse units without requiring parentheses

## Testing
- `php -l wp-content/plugins/wp-loft-booking-plugin/includes/ajax/ajax-handlers.php`
- `php -l wp-content/plugins/wp-loft-booking-plugin/includes/shortcodes/display-results.php`
- `php -r "include 'wp-load.php'; wp_loft_booking_sync_units(); echo get_post_meta(13804, 'nd_booking_meta_box_qnt', true);"` *(fails: Error establishing a database connection)*


------
https://chatgpt.com/codex/tasks/task_e_689bba4850608329a1f82666d5b64565