### PR TITLE
Add client profile shortcode and styling

### DIFF
--- a/public_html/wp-content/plugins/simplified-food-fitness/assets/css/sff-styles.css
+++ b/public_html/wp-content/plugins/simplified-food-fitness/assets/css/sff-styles.css
@@ -1,0 +1,8 @@
+.sff-profile-card {
+    background-color: #fff;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    padding: 1rem;
+    margin-bottom: 1rem;
+    box-shadow: 0 1px 1px rgba(0,0,0,0.05);
+}

--- a/public_html/wp-content/plugins/simplified-food-fitness/includes/shortcodes.php
+++ b/public_html/wp-content/plugins/simplified-food-fitness/includes/shortcodes.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Shortcodes for Simplified Food Fitness plugin.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+/**
+ * Display the logged-in client's profile information.
+ *
+ * @return string HTML output for the client profile.
+ */
+function sff_client_profile_shortcode() {
+    if ( ! is_user_logged_in() ) {
+        return '';
+    }
+
+    $args  = array(
+        'post_type'      => 'clients',
+        'posts_per_page' => 1,
+        'meta_key'       => 'linked_user_id',
+        'meta_value'     => get_current_user_id(),
+        'post_status'    => 'publish',
+        'fields'         => 'ids',
+    );
+
+    $query = new WP_Query( $args );
+
+    if ( ! $query->have_posts() ) {
+        return '';
+    }
+
+    $client_id = $query->posts[0];
+
+    $fields = array(
+        'first_name' => __( 'First Name', 'sff' ),
+        'last_name'  => __( 'Last Name', 'sff' ),
+        'email'      => __( 'Email', 'sff' ),
+        'phone'      => __( 'Phone', 'sff' ),
+    );
+
+    $output = '<div class="sff-profile-card">';
+
+    foreach ( $fields as $meta_key => $label ) {
+        $value = get_post_meta( $client_id, $meta_key, true );
+        if ( $value ) {
+            $output .= '<p><strong>' . esc_html( $label ) . ':</strong> ' . esc_html( $value ) . '</p>';
+        }
+    }
+
+    $output .= '</div>';
+
+    wp_reset_postdata();
+
+    return $output;
+}
+add_shortcode( 'sff_client_profile', 'sff_client_profile_shortcode' );
+
+/**
+ * Render the frontend dashboard.
+ *
+ * @return string HTML output for the dashboard.
+ */
+function sff_frontend_dashboard_pretty() {
+    $output  = '<div class="sff-dashboard">';
+    $output .= do_shortcode( '[sff_client_profile]' );
+    $output .= '<!-- Dashboard content will be added here -->';
+    $output .= '</div>';
+
+    return $output;
+}

--- a/public_html/wp-content/plugins/simplified-food-fitness/simplified-food-fitness.php
+++ b/public_html/wp-content/plugins/simplified-food-fitness/simplified-food-fitness.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Plugin Name: Simplified Food Fitness
+ * Description: Provides client dashboard and profile management for Simplified Food Fitness.
+ * Version: 0.1.0
+ * Author: Loft1325
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+// Plugin constants.
+define( 'SFF_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+define( 'SFF_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+
+// Include shortcode functionality.
+require_once SFF_PLUGIN_DIR . 'includes/shortcodes.php';
+
+// Enqueue plugin styles.
+function sff_enqueue_assets() {
+    wp_enqueue_style( 'sff-styles', SFF_PLUGIN_URL . 'assets/css/sff-styles.css', array(), '0.1.0' );
+}
+add_action( 'wp_enqueue_scripts', 'sff_enqueue_assets' );


### PR DESCRIPTION
## Summary
- implement `[sff_client_profile]` shortcode to display logged-in client profile and include it in the dashboard
- enqueue plugin stylesheet for profile card layout

## Testing
- `php -l public_html/wp-content/plugins/simplified-food-fitness/simplified-food-fitness.php`
- `php -l public_html/wp-content/plugins/simplified-food-fitness/includes/shortcodes.php`


------
https://chatgpt.com/codex/tasks/task_e_689e1812a83c8329a994451aa407d010