### PR TITLE
Trigger Amelia webhook after booking

### DIFF
--- a/public_html/wp-content/plugins/wp-loft-booking-plugin/includes/admin/bookings.php
+++ b/public_html/wp-content/plugins/wp-loft-booking-plugin/includes/admin/bookings.php
@@ -96,5 +96,21 @@ function wp_loft_booking_process_booking($email, $room_type, $checkin, $checkout
     $cleaning_time = date('Y-m-d H:i:s', strtotime($checkout . ' +1 hour'));
     schedule_cleaning_task("Cleaning: {$loft->unit_name}", $cleaning_time);
 
+    if (function_exists('trigger_amelia_booking_webhook')) {
+        $amelia_data = [
+            'first_name' => $first_name,
+            'last_name'  => $last_name,
+            'email'      => $email,
+            'checkin'    => $checkin,
+            'checkout'   => $checkout,
+            'unit'       => [
+                'id'     => $loft->id,
+                'name'   => $loft->unit_name,
+                'api_id' => $loft->unit_id_api,
+            ],
+        ];
+        trigger_amelia_booking_webhook($amelia_data);
+    }
+
     error_log('✅ Booking automation completed.');
 }

--- a/public_html/wp-content/plugins/wp-loft-booking-plugin/wp-loft-booking-plugin.php
+++ b/public_html/wp-content/plugins/wp-loft-booking-plugin/wp-loft-booking-plugin.php
@@ -24,7 +24,7 @@ require_once plugin_dir_path(__FILE__) . 'includes/admin/payment-settings.php';
 require_once plugin_dir_path(__FILE__) . 'includes/admin/tenants.php';
 require_once plugin_dir_path(__FILE__) . 'includes/integrations/butterflymx.php';
 require_once plugin_dir_path(__FILE__) . 'includes/integrations/booking-handler.php';
-require_once plugin_dir_path(__FILE__) . 'includes/integrations/amelia_hooks.php';
+require_once plugin_dir_path(__FILE__) . 'includes/integrations/amelia-hooks.php';
 require_once plugin_dir_path(__FILE__) . 'includes/shortcodes/booking-form.php';
 require_once plugin_dir_path(__FILE__) . 'includes/shortcodes/search-form.php';
 require_once plugin_dir_path(__FILE__) . 'includes/shortcodes/display-results.php';


### PR DESCRIPTION
## Summary
- Send guest and unit details to Amelia via `trigger_amelia_booking_webhook` after Google Calendar scheduling
- Ensure Amelia integration file is included so the webhook is available

## Testing
- `php -l public_html/wp-content/plugins/wp-loft-booking-plugin/includes/admin/bookings.php`
- `php -l public_html/wp-content/plugins/wp-loft-booking-plugin/wp-loft-booking-plugin.php`


------
https://chatgpt.com/codex/tasks/task_e_68a71729e61883298495848f95ade73c