### PR TITLE
Remove forced HTTPS rewrite block

### DIFF
--- a/public_html/.htaccess
+++ b/public_html/.htaccess
@@ -1,13 +1,4 @@
 
-# BEGIN WP_Encryption_Force_SSL
-<IfModule mod_rewrite.c>
-RewriteEngine on
-RewriteCond %{HTTPS} !=on [NC]
-RewriteCond %{HTTP:X-Forwarded-Proto} !https
-RewriteCond %{REQUEST_URI} !^/\.well-known/acme-challenge/
-RewriteRule ^(.*)$ https://%{HTTP_HOST}/$1 [R=301,L]
-</IfModule>
-# END WP_Encryption_Force_SSL
 # BEGIN WordPress
 # The directives (lines) between "BEGIN WordPress" and "END WordPress" are
 # dynamically generated, and should only be modified via WordPress filters.


### PR DESCRIPTION
## Summary
- remove WP_Encryption_Force_SSL rewrite block from .htaccess

## Testing
- `apache2ctl -t` *(fails: command not found)*
- `apachectl -t` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb23cde020832989fef7ac477bfc87