### PR TITLE
Fix Google Calendar booking argument mismatch

### DIFF
--- a/public_html/wp-content/plugins/nd-booking/inc/shortcodes/nd_booking_checkout.php
+++ b/public_html/wp-content/plugins/nd-booking/inc/shortcodes/nd_booking_checkout.php
@@ -597,16 +597,17 @@ function nd_booking_shortcode_checkout() {
         update_post_meta( $nd_booking_booking_id, 'guest_id_type', sanitize_text_field( $nd_booking_guest_id_type ) );
 
         if (function_exists('add_booking_to_google_calendar')) {
-            $args = [
-                'name'        => $nd_booking_booking_form_name,
-                'surname'     => $nd_booking_booking_form_surname,
-                'email'       => $nd_booking_booking_form_email,
-                'start'       => $nd_booking_booking_form_date_from,
-                'end'         => $nd_booking_booking_form_date_to,
-                'room_id'     => $nd_booking_id_room,
-                // add other fields as needed
-            ];
-            add_booking_to_google_calendar($args);
+            $summary = sprintf(
+                'Booking for %s %s',
+                $nd_booking_booking_form_name,
+                $nd_booking_booking_form_surname
+            );
+
+            add_booking_to_google_calendar(
+                $summary,
+                $nd_booking_booking_form_date_from,
+                $nd_booking_booking_form_date_to
+            );
         }
         if (function_exists('create_keychain_in_butterflymx')) {
             $args = [

--- a/public_html/wp-content/plugins/wp-loft-booking-plugin/includes/calendar/google-calendar.php
+++ b/public_html/wp-content/plugins/wp-loft-booking-plugin/includes/calendar/google-calendar.php
@@ -47,8 +47,38 @@ function loft_booking_get_google_auth_url() {
 
 
 function add_booking_to_google_calendar($summary, $start, $end) {
-    $calendar_id = get_option('loft_booking_calendar_id');
-    return create_google_event($summary, 'Automated guest booking.', date('c', strtotime($start)), date('c', strtotime($end)), $calendar_id);
+    $calendar_id  = get_option('loft_booking_calendar_id');
+    $access_token = get_option('google_calendar_access_token');
+
+    $event = [
+        'summary'     => $summary,
+        'description' => 'Automated guest booking.',
+        'start'       => [
+            'dateTime' => date('c', strtotime($start)),
+            'timeZone' => 'America/Toronto',
+        ],
+        'end'         => [
+            'dateTime' => date('c', strtotime($end)),
+            'timeZone' => 'America/Toronto',
+        ],
+    ];
+
+    $response = wp_remote_post("https://www.googleapis.com/calendar/v3/calendars/{$calendar_id}/events", [
+        'headers' => [
+            'Authorization' => 'Bearer ' . $access_token,
+            'Content-Type'  => 'application/json',
+        ],
+        'body' => json_encode($event),
+    ]);
+
+    error_log("\xF0\x9F\x93\xA4 Google Calendar API response: " . print_r($response, true));
+
+    if (is_wp_error($response)) {
+        error_log("\xE2\x9D\x8C Google Calendar error: " . $response->get_error_message());
+        return false;
+    }
+
+    return json_decode(wp_remote_retrieve_body($response), true);
 }
 
 add_action('admin_footer', function() {


### PR DESCRIPTION
## Summary
- Pass summary, start and end as individual parameters when scheduling bookings with Google Calendar
- Build event payload and post to Google Calendar API inside `add_booking_to_google_calendar`

## Testing
- `php -l public_html/wp-content/plugins/nd-booking/inc/shortcodes/nd_booking_checkout.php`
- `php -l public_html/wp-content/plugins/wp-loft-booking-plugin/includes/calendar/google-calendar.php`
- `php -r 'function get_option($k){return "test";} function wp_remote_post($url,$args){return ["body"=>"{}","response"=>["code"=>200]];} function is_wp_error($r){return false;} function wp_remote_retrieve_body($r){return $r["body"];}; function add_action($hook,$cb){;} require "public_html/wp-content/plugins/wp-loft-booking-plugin/includes/calendar/google-calendar.php"; add_booking_to_google_calendar("Test","2024-01-01","2024-01-02");'`


------
https://chatgpt.com/codex/tasks/task_e_68c25f78f4d8832980355cfd5fe0b0a2