### PR TITLE
Handle missing booking unit by selecting first available

### DIFF
--- a/public_html/wp-content/plugins/wp-loft-booking-plugin/includes/integrations/booking-handler.php
+++ b/public_html/wp-content/plugins/wp-loft-booking-plugin/includes/integrations/booking-handler.php
@@ -28,6 +28,8 @@ function wp_loft_booking_handle_booking(
     $paypal_tx,
     $action_type
 ) {
+    global $wpdb;
+
     $booking = [
         'room_id'   => $id_post,
         'name'      => $user_first_name,
@@ -37,6 +39,31 @@ function wp_loft_booking_handle_booking(
         'date_from' => $date_from,
         'date_to'   => $date_to,
     ];
+
+    $units_table    = $wpdb->prefix . 'loft_units';
+    $bookings_table = $wpdb->prefix . 'loft_bookings';
+
+    $has_valid_unit = !empty($booking['room_id']) && $wpdb->get_var(
+        $wpdb->prepare("SELECT id FROM {$units_table} WHERE id = %d", $booking['room_id'])
+    );
+
+    if (!$has_valid_unit) {
+        $available_unit = $wpdb->get_var(
+            "SELECT id FROM {$units_table} WHERE status = 'available' ORDER BY unit_name ASC LIMIT 1"
+        );
+
+        if ($available_unit) {
+            $booking['room_id'] = intval($available_unit);
+
+            $wpdb->update(
+                $bookings_table,
+                ['unit_id' => $booking['room_id']],
+                ['id' => $id_post],
+                ['%d'],
+                ['%d']
+            );
+        }
+    }
 
     // 🔐 Generar llave virtual con ButterflyMX
     wp_loft_booking_generate_virtual_key(


### PR DESCRIPTION
## Summary
- choose first available `loft_units` entry when booking lacks a valid unit
- persist the selected `unit_id` into `loft_bookings`
- use the chosen unit when generating virtual keys

## Testing
- `php -l public_html/wp-content/plugins/wp-loft-booking-plugin/includes/integrations/booking-handler.php`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c26780ed888329a06fdf7957c11fed