### PR TITLE
Hook Stripe payment to Loft booking automation

### DIFF
--- a/public_html/wp-content/plugins/nd-booking/inc/shortcodes/nd_booking_checkout.php
+++ b/public_html/wp-content/plugins/nd-booking/inc/shortcodes/nd_booking_checkout.php
@@ -310,7 +310,11 @@ function nd_booking_shortcode_checkout() {
                     $nd_booking_response_body = wp_remote_retrieve_body( $nd_booking_response );
                     $nd_booking_stripe_data = json_decode( $nd_booking_response_body );
 
-                    if ( $nd_booking_stripe_data->paid == 1 ) { $nd_booking_booking_form_payment_status = 'Completed'; }
+                    if ( $nd_booking_stripe_data->paid == 1 ) {
+                        $nd_booking_booking_form_payment_status = 'Completed';
+                        // store the payment id for later use
+                        $nd_booking_booking_form_payment_id     = $nd_booking_stripe_data->id;
+                    }
 
                     //transaction TX id
                     $nd_booking_paypal_tx = $nd_booking_stripe_data->id;
@@ -595,6 +599,23 @@ function nd_booking_shortcode_checkout() {
         update_post_meta( $nd_booking_booking_id, 'guest_id_back', esc_url_raw( $nd_booking_guest_id_back ) );
         update_post_meta( $nd_booking_booking_id, 'guest_id_number', sanitize_text_field( $nd_booking_guest_id_number ) );
         update_post_meta( $nd_booking_booking_id, 'guest_id_type', sanitize_text_field( $nd_booking_guest_id_type ) );
+
+        if (
+            $nd_booking_booking_form_action_type === 'stripe' &&
+            $nd_booking_booking_form_payment_status === 'Completed'
+        ) {
+            $payload = [
+                'guest_email'   => $nd_booking_booking_form_email,
+                'room_type'     => $nd_booking_checkout_form_post_title,
+                'check_in_date' => $nd_booking_booking_form_date_from,
+                'check_out_date'=> $nd_booking_booking_form_date_to,
+                'booking_id'    => $nd_booking_booking_id,
+                'first_name'    => $nd_booking_booking_form_name,
+                'last_name'     => $nd_booking_booking_form_surname,
+            ];
+
+            do_action( 'nd_booking_stripe_payment_complete', $payload );
+        }
 
         if (function_exists('add_booking_to_google_calendar')) {
             $summary = sprintf(

--- a/public_html/wp-content/plugins/wp-loft-booking-plugin/includes/admin/bookings.php
+++ b/public_html/wp-content/plugins/wp-loft-booking-plugin/includes/admin/bookings.php
@@ -39,6 +39,7 @@ update_option('loft_booking_cleaning_calendar_id', 'e964e301b54d0e795b44a76ebfb9
 update_option('loft_booking_calendar_id', 'a752f27cffee8c22988adb29fdc933c93184e3a5814c79dcee4f62115d69fbfd@group.calendar.google.com');
 
 add_action('wc_stripe_webhook_payment_intent_succeeded', 'wp_loft_booking_stripe_payment_succeeded', 10, 2);
+add_action('nd_booking_stripe_payment_complete', 'wp_loft_booking_nd_stripe_payment_complete', 10, 1);
 
 function wp_loft_booking_stripe_payment_succeeded($order, $event) {
     $intent = $event->data->object ?? null;
@@ -54,6 +55,18 @@ function wp_loft_booking_stripe_payment_succeeded($order, $event) {
     $first_name = $meta->first_name ?? 'Guest';
     $last_name  = $meta->last_name ?? 'Booking';
     $booking_id = isset($meta->booking_id) ? intval($meta->booking_id) : 0;
+
+    wp_loft_booking_process_booking($email, $room_type, $checkin, $checkout, $first_name, $last_name, $booking_id);
+}
+
+function wp_loft_booking_nd_stripe_payment_complete($payload) {
+    $email      = $payload['guest_email']   ?? '';
+    $room_type  = $payload['room_type']     ?? '';
+    $checkin    = $payload['check_in_date'] ?? '';
+    $checkout   = $payload['check_out_date'] ?? '';
+    $booking_id = isset($payload['booking_id']) ? intval($payload['booking_id']) : 0;
+    $first_name = $payload['first_name']    ?? 'Guest';
+    $last_name  = $payload['last_name']     ?? 'Booking';
 
     wp_loft_booking_process_booking($email, $room_type, $checkin, $checkout, $first_name, $last_name, $booking_id);
 }


### PR DESCRIPTION
## Summary
- Trigger custom `nd_booking_stripe_payment_complete` after successful Stripe charge with booking details.
- Listen for the action in Loft Booking plugin and forward data to `wp_loft_booking_process_booking()`.

## Testing
- `php -l public_html/wp-content/plugins/nd-booking/inc/shortcodes/nd_booking_checkout.php`
- `php -l public_html/wp-content/plugins/wp-loft-booking-plugin/includes/admin/bookings.php`


------
https://chatgpt.com/codex/tasks/task_e_68c270f6978083298ec86de3c3b7583a