### PR TITLE
Load Google API client and handle missing credentials

### DIFF
--- a/public_html/wp-content/plugins/wp-loft-booking-plugin/includes/calendar/google-oauth-handler.php
+++ b/public_html/wp-content/plugins/wp-loft-booking-plugin/includes/calendar/google-oauth-handler.php
@@ -75,6 +75,73 @@ function loft_booking_get_valid_access_token() {
     return false;
 }
 
+/**
+ * Return an authenticated Google_Client instance.
+ *
+ * Attempts to load the Google API PHP Client library and configure the
+ * client with stored credentials. Returns false on failure.
+ *
+ * @return Google_Client|false
+ */
+function wp_loft_get_google_client() {
+    $client_id     = '1057657895142-bkv4nmceeie0b79s3l6nuv9v8c8t5mbn.apps.googleusercontent.com';
+    $client_secret = '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';
+    $refresh_token = get_option('loft_google_refresh_token');
+
+    if (empty($client_id) || empty($client_secret) || empty($refresh_token)) {
+        error_log('⚠️ Google Calendar credentials are missing.');
+        return false;
+    }
+
+    // Load Google API PHP Client if it's not already available.
+    if (!class_exists('Google_Client')) {
+        $autoload = WP_PLUGIN_DIR . '/ameliabooking/vendor/autoload.php';
+        if (file_exists($autoload)) {
+            require_once $autoload;
+        }
+    }
+
+    if (!class_exists('Google_Client')) {
+        error_log('⚠️ Google API client library not found.');
+        return false;
+    }
+
+    $client = new Google_Client();
+    $client->setClientId($client_id);
+    $client->setClientSecret($client_secret);
+    $client->setRedirectUri(admin_url('admin.php?page=loft-booking-google-auth'));
+    $client->addScope(Google_Service_Calendar::CALENDAR);
+    $client->setAccessType('offline');
+
+    $access_token = loft_booking_get_valid_access_token();
+    if (!$access_token) {
+        error_log('⚠️ Google access token is missing or invalid.');
+        return false;
+    }
+
+    $client->setAccessToken($access_token);
+
+    if ($client->isAccessTokenExpired()) {
+        try {
+            $new_token = $client->fetchAccessTokenWithRefreshToken($refresh_token);
+            if (!isset($new_token['access_token'])) {
+                error_log('❌ Failed to refresh Google access token.');
+                return false;
+            }
+            update_option('loft_google_access_token', $new_token['access_token']);
+            if (isset($new_token['expires_in'])) {
+                update_option('loft_google_token_expires', time() + $new_token['expires_in']);
+            }
+            $client->setAccessToken($new_token);
+        } catch (Exception $e) {
+            error_log('❌ Error refreshing Google access token: ' . $e->getMessage());
+            return false;
+        }
+    }
+
+    return $client;
+}
+
 function create_google_event($summary, $description, $start, $end, $calendar_id = null) {
     $access_token = get_option('google_calendar_access_token');
 

--- a/public_html/wp-content/plugins/wp-loft-booking-plugin/includes/integrations/booking-handler.php
+++ b/public_html/wp-content/plugins/wp-loft-booking-plugin/includes/integrations/booking-handler.php
@@ -116,7 +116,12 @@ function wp_loft_booking_generate_virtual_key($unit_id, $name, $email, $phone, $
 }
 
 function wp_loft_booking_create_google_event($booking) {
-    $client = wp_loft_get_google_client(); // Asumes que ya tienes esto en google-oauth-handler.php
+    $client = wp_loft_get_google_client();
+    if (!$client) {
+        error_log('⚠️ Google Client unavailable. Skipping calendar event creation.');
+        return;
+    }
+
     $service = new Google_Service_Calendar($client);
 
     $event = new Google_Service_Calendar_Event([


### PR DESCRIPTION
## Summary
- Add `wp_loft_get_google_client` helper to load Google API library, configure OAuth credentials, and refresh tokens.
- Skip Google Calendar event creation when the Google client can't be initialized.

## Testing
- `php -l public_html/wp-content/plugins/wp-loft-booking-plugin/includes/calendar/google-oauth-handler.php`
- `php -l public_html/wp-content/plugins/wp-loft-booking-plugin/includes/integrations/booking-handler.php`


------
https://chatgpt.com/codex/tasks/task_e_68c2795e6040832998e28f5010e6d6f4