### PR TITLE
Add tax breakdown across booking, checkout, and communications

### DIFF
--- a/public_html/wp-content/plugins/nd-booking/addons/message/index.php
+++ b/public_html/wp-content/plugins/nd-booking/addons/message/index.php
@@ -145,11 +145,43 @@ if ( $nd_booking_message_enable == 1 and get_option('nicdark_theme_author') == 1
 
 
 	   
-	    //get logo
-		$nd_booking_customizer_logo = get_option( 'nicdark_customizer_logo_img' );
-		if ( $nd_booking_customizer_logo == '' ) { 
-		 	$nd_booking_email_logo = '';  
-		}else{
+            //tax breakdown
+            $nd_booking_email_tax_breakdown = nd_booking_calculate_tax_breakdown_from_total( $nd_booking_final_trip_price );
+            $nd_booking_email_subtotal = nd_booking_format_decimal( $nd_booking_email_tax_breakdown['base'] );
+            $nd_booking_email_total_tax = nd_booking_format_decimal( $nd_booking_email_tax_breakdown['total_tax'] );
+            $nd_booking_email_grand_total = nd_booking_format_decimal( $nd_booking_email_tax_breakdown['total'] );
+
+            $nd_booking_email_known_tax_labels = array(
+                'lodging' => __( 'Lodging Tax', 'nd-booking' ),
+                'gst'     => __( 'GST', 'nd-booking' ),
+                'qst'     => __( 'QST', 'nd-booking' ),
+            );
+
+            $nd_booking_email_tax_lines_default = '<p>'.__( 'Subtotal', 'nd-booking' ).' : '.$nd_booking_email_subtotal.' '.$nd_booking_paypal_currency.'</p>';
+            $nd_booking_email_tax_lines_template = '<p style="margin:0px; padding:0px; float:left; width:100%; color:#878787;">'.__( 'Subtotal', 'nd-booking' ).' : '.$nd_booking_email_subtotal.' '.$nd_booking_paypal_currency.'</p>';
+
+            foreach ( $nd_booking_email_known_tax_labels as $nd_booking_tax_key => $nd_booking_tax_label ) {
+                if ( isset( $nd_booking_email_tax_breakdown['taxes'][ $nd_booking_tax_key ] ) && $nd_booking_email_tax_breakdown['taxes'][ $nd_booking_tax_key ]['amount'] > 0 ) {
+                    $nd_booking_tax_rate = nd_booking_format_percentage( $nd_booking_email_tax_breakdown['taxes'][ $nd_booking_tax_key ]['rate'] );
+                    $nd_booking_tax_amount_formatted = nd_booking_format_decimal( $nd_booking_email_tax_breakdown['taxes'][ $nd_booking_tax_key ]['amount'] );
+                    $nd_booking_display_label = sprintf( __( '%1$s (%2$s%%)', 'nd-booking' ), $nd_booking_email_tax_breakdown['taxes'][ $nd_booking_tax_key ]['label'], $nd_booking_tax_rate );
+                    $nd_booking_email_tax_lines_default .= '<p>'.$nd_booking_display_label.' : '.$nd_booking_tax_amount_formatted.' '.$nd_booking_paypal_currency.'</p>';
+                    $nd_booking_email_tax_lines_template .= '<p style="margin:0px; padding:0px; float:left; width:100%; color:#878787;">'.$nd_booking_display_label.' : '.$nd_booking_tax_amount_formatted.' '.$nd_booking_paypal_currency.'</p>';
+                }
+            }
+
+            $nd_booking_email_tax_lines_default .= '<p>'.__( 'Total Tax', 'nd-booking' ).' : '.$nd_booking_email_total_tax.' '.$nd_booking_paypal_currency.'</p>';
+            $nd_booking_email_tax_lines_default .= '<p>'.__( 'Grand Total', 'nd-booking' ).' : '.$nd_booking_email_grand_total.' '.$nd_booking_paypal_currency.'</p>';
+
+            $nd_booking_email_tax_lines_template .= '<div style="float:left; width:100%; height:10px;"></div>';
+            $nd_booking_email_tax_lines_template .= '<p style="margin:0px; padding:0px; float:left; width:100%; color:#878787; font-weight:bold;">'.__( 'Total Tax', 'nd-booking' ).' : '.$nd_booking_email_total_tax.' '.$nd_booking_paypal_currency.'</p>';
+            $nd_booking_email_tax_lines_template .= '<p style="margin:0px; padding:0px; float:left; width:100%; color:#878787; font-weight:bold;">'.__( 'Grand Total', 'nd-booking' ).' : '.$nd_booking_email_grand_total.' '.$nd_booking_paypal_currency.'</p>';
+
+            //get logo
+            $nd_booking_customizer_logo = get_option( 'nicdark_customizer_logo_img' );
+            if ( $nd_booking_customizer_logo == '' ) {
+                    $nd_booking_email_logo = '';
+            }else{
 		    $nd_booking_customizer_logo_src = wp_get_attachment_url($nd_booking_customizer_logo);
 		    $nd_booking_email_logo = '<img src="'.$nd_booking_customizer_logo_src.'">';  
 		}
@@ -180,8 +212,8 @@ if ( $nd_booking_message_enable == 1 and get_option('nicdark_theme_author') == 1
 		  <p>'.__('Date To','nd-booking').' : '.$nd_booking_date_to.'</p>
 		  <p>'.__('Guests','nd-booking').' : '.$nd_booking_guests.'</p><br/>
 
-		  <p><strong>'.__('TOTAL PRICE','nd-booking').' :</strong></p>
-		  <p>'.__('Price','nd-booking').' : '.$nd_booking_final_trip_price.' '.$nd_booking_paypal_currency.'</p><br/>
+                  <p><strong>'.__('TOTAL PRICE','nd-booking').' :</strong></p>
+                  '.$nd_booking_email_tax_lines_default.'<br/>
 
 		  <p><strong>'.__('EXTRA SERVICES ( included in the price )','nd-booking').' :</strong></p>
 		  '.$nd_booking_extra_services_result.'<br/>
@@ -267,9 +299,9 @@ if ( $nd_booking_message_enable == 1 and get_option('nicdark_theme_author') == 1
 					<div style="float:left; width:100%; height:40px;"></div>
 					<h2 style="float:left; width:100%; text-align:center; color:#727475; font-weight:normal; margin:0px; padding:0px;">'.__('Total Price','nd-booking').' :</h2>
 					<div style="float:left; width:100%; height:20px;"></div>
-					<div style="float:left; width:100%; background-color:#f9f9f9; padding:20px; box-sizing:border-box;">
-						<p style="margin:0px; padding:0px; float:left; width:100%; color:#878787;">'.__('Price','nd-booking').' : '.$nd_booking_final_trip_price.' '.$nd_booking_paypal_currency.'</p>
-					</div>
+                                        <div style="float:left; width:100%; background-color:#f9f9f9; padding:20px; box-sizing:border-box;">
+                                                '.$nd_booking_email_tax_lines_template.'
+                                        </div>
 					
 				</div>
 				<!--START SECTION-->

--- a/public_html/wp-content/plugins/nd-booking/assets/js/final_price.js
+++ b/public_html/wp-content/plugins/nd-booking/assets/js/final_price.js
@@ -1,43 +1,108 @@
-
 //START function
 function nd_booking_final_price(){
 
   jQuery( "body" ).append( "<div id='nd_booking_sorting_result_layer' class='nd_booking_cursor_progress nd_booking_position_fixed nd_booking_width_100_percentage nd_booking_height_100_percentage nd_booking_z_index_999'></div>" );
 
-  var nd_booking_booking_checkbox_services = jQuery( "#nd_booking_booking_checkbox_services").val();
-  var nd_booking_booking_form_final_price = jQuery( "#nd_booking_booking_form_trip_price").val();
+  var nd_booking_booking_checkbox_services = jQuery( "#nd_booking_booking_checkbox_services" ).val();
+  var nd_booking_booking_form_final_price = jQuery( "#nd_booking_booking_form_trip_price" ).val();
 
-  //START post method
+  var nd_booking_request_data = {
+    action : 'nd_booking_final_price_php',
+    nd_booking_booking_checkbox_services : nd_booking_booking_checkbox_services,
+    nd_booking_booking_form_final_price : nd_booking_booking_form_final_price
+  };
+
+  if ( typeof nd_booking_my_vars_final_price !== 'undefined' && nd_booking_my_vars_final_price.nd_booking_ajaxnonce_final_price ) {
+    nd_booking_request_data.nd_booking_final_price_security = nd_booking_my_vars_final_price.nd_booking_ajaxnonce_final_price;
+  }
+
   jQuery.get(
-    
-  
-    //ajax
     nd_booking_my_vars_final_price.nd_booking_ajaxurl_final_price,
-    {
-      action : 'nd_booking_final_price_php',
-      nd_booking_booking_checkbox_services : nd_booking_booking_checkbox_services,
-      nd_booking_booking_form_final_price : nd_booking_booking_form_final_price
-    },
-    //end ajax
+    nd_booking_request_data,
+    null,
+    'json'
+  )
+  .done(function( response ) {
 
+    if ( response && response.success && response.data ) {
 
-    //START success
-    function( nd_booking_booking_result ) {
+      var data = response.data;
+      var currency = data.currency || '';
 
       jQuery( "#nd_booking_final_trip_price span" ).empty();
-      jQuery( "#nd_booking_final_trip_price span" ).text(nd_booking_booking_result);
-      jQuery( "#nd_booking_booking_form_final_price").val(nd_booking_booking_result);
+      jQuery( "#nd_booking_final_trip_price span" ).text( data.total_formatted );
+      jQuery( "#nd_booking_booking_form_final_price" ).val( data.total_raw );
 
-      jQuery( "#nd_booking_sorting_result_layer" ).remove(); 
+      if ( jQuery( "#nd_booking_booking_form_base_price" ).length ) {
+        jQuery( "#nd_booking_booking_form_base_price" ).val( data.base_raw );
+      }
+
+      nd_booking_update_tax_breakdown( data, currency );
 
     }
-    //END
 
-    
+  })
+  .always(function() {
 
-  );
-  //END
+    jQuery( "#nd_booking_sorting_result_layer" ).remove();
 
-  
+  });
+
+
 }
 //END function
+
+function nd_booking_update_tax_breakdown( data, currency ) {
+
+  var container = jQuery( ".nd_booking_tax_breakdown" );
+
+  if ( ! container.length ) {
+    return;
+  }
+
+  var subtotalLabel = data.subtotal_label || 'Subtotal';
+  var totalTaxLabel = data.total_tax_label || 'Total Tax';
+  var grandTotalLabel = data.grand_total_label || 'Grand Total';
+
+  var subtotalLine = container.find( '[data-tax-key="subtotal"]' );
+  subtotalLine.find( '.nd_booking_tax_label' ).text( subtotalLabel );
+  subtotalLine.find( '.nd_booking_tax_amount' ).text( data.base_formatted || data.base_raw || '0.00' );
+  subtotalLine.find( '.nd_booking_tax_currency' ).text( currency );
+  subtotalLine.show();
+
+  var handledKeys = {};
+  if ( Array.isArray( data.taxes ) ) {
+    for ( var i = 0; i < data.taxes.length; i++ ) {
+      var tax = data.taxes[i];
+      var key = tax.key;
+      handledKeys[key] = true;
+      var taxLine = container.find( '[data-tax-key="' + key + '"]' );
+      if ( taxLine.length ) {
+        taxLine.find( '.nd_booking_tax_label' ).text( tax.display_label || tax.label );
+        taxLine.find( '.nd_booking_tax_amount' ).text( tax.amount_formatted || tax.amount_raw || '0.00' );
+        taxLine.find( '.nd_booking_tax_currency' ).text( currency );
+        taxLine.show();
+      }
+    }
+  }
+
+  container.find( '[data-tax-key]' ).each(function() {
+    var key = jQuery( this ).data( 'tax-key' );
+    if ( key && key !== 'subtotal' && key !== 'total_tax' && key !== 'grand_total' && ! handledKeys[key] ) {
+      jQuery( this ).hide();
+    }
+  });
+
+  var totalTaxLine = container.find( '[data-tax-key="total_tax"]' );
+  totalTaxLine.find( '.nd_booking_tax_label' ).text( totalTaxLabel );
+  totalTaxLine.find( '.nd_booking_tax_amount' ).text( data.total_tax_formatted || data.total_tax_raw || '0.00' );
+  totalTaxLine.find( '.nd_booking_tax_currency' ).text( currency );
+  totalTaxLine.show();
+
+  var grandTotalLine = container.find( '[data-tax-key="grand_total"]' );
+  grandTotalLine.find( '.nd_booking_tax_label' ).text( grandTotalLabel );
+  grandTotalLine.find( '.nd_booking_tax_amount' ).text( data.total_formatted || data.total_raw || '0.00' );
+  grandTotalLine.find( '.nd_booking_tax_currency' ).text( currency );
+  grandTotalLine.show();
+
+}

--- a/public_html/wp-content/plugins/nd-booking/inc/functions/functions.php
+++ b/public_html/wp-content/plugins/nd-booking/inc/functions/functions.php
@@ -768,9 +768,146 @@ function nd_booking_order_page() {
 
 function nd_booking_get_currency(){
 
-	$nd_booking_currency = get_option('nd_booking_currency');
+        $nd_booking_currency = get_option('nd_booking_currency');
 
-	return $nd_booking_currency;
+        return $nd_booking_currency;
+
+}
+
+function nd_booking_format_decimal( $amount, $decimals = 2 ) {
+
+        $amount = floatval( $amount );
+
+        return number_format( $amount, $decimals, '.', '' );
+
+}
+
+function nd_booking_format_percentage( $rate ) {
+
+        $rate = floatval( $rate );
+
+        if ( 0.0 === $rate ) {
+                return '0';
+        }
+
+        $formatted = number_format( $rate, 3, '.', '' );
+        $formatted = rtrim( rtrim( $formatted, '0' ), '.' );
+
+        return $formatted;
+
+}
+
+function nd_booking_calculate_tax_breakdown( $base_amount ) {
+
+        $base_amount = max( 0, floatval( $base_amount ) );
+
+        $rates = array(
+                'lodging' => floatval( get_option( 'nd_booking_lodging_tax_rate', 0 ) ),
+                'gst'     => floatval( get_option( 'nd_booking_gst_rate', 0 ) ),
+                'qst'     => floatval( get_option( 'nd_booking_qst_rate', 0 ) ),
+        );
+
+        $labels = array(
+                'lodging' => __( 'Lodging Tax', 'nd-booking' ),
+                'gst'     => __( 'GST', 'nd-booking' ),
+                'qst'     => __( 'QST', 'nd-booking' ),
+        );
+
+        $taxes = array();
+
+        $lodging_amount = 0.0;
+        if ( $rates['lodging'] > 0 ) {
+                $lodging_amount = round( $base_amount * $rates['lodging'] / 100, 2 );
+                $taxes['lodging'] = array(
+                        'label'         => $labels['lodging'],
+                        'rate'          => $rates['lodging'],
+                        'amount'        => $lodging_amount,
+                        'display_label' => sprintf( __( '%1$s (%2$s%%)', 'nd-booking' ), $labels['lodging'], nd_booking_format_percentage( $rates['lodging'] ) ),
+                );
+        }
+
+        $gst_amount = 0.0;
+        if ( $rates['gst'] > 0 ) {
+                $gst_amount = round( $base_amount * $rates['gst'] / 100, 2 );
+                $taxes['gst'] = array(
+                        'label'         => $labels['gst'],
+                        'rate'          => $rates['gst'],
+                        'amount'        => $gst_amount,
+                        'display_label' => sprintf( __( '%1$s (%2$s%%)', 'nd-booking' ), $labels['gst'], nd_booking_format_percentage( $rates['gst'] ) ),
+                );
+        }
+
+        $qst_amount = 0.0;
+        if ( $rates['qst'] > 0 ) {
+                $qst_amount = round( ( $base_amount + $gst_amount ) * $rates['qst'] / 100, 2 );
+                $taxes['qst'] = array(
+                        'label'         => $labels['qst'],
+                        'rate'          => $rates['qst'],
+                        'amount'        => $qst_amount,
+                        'display_label' => sprintf( __( '%1$s (%2$s%%)', 'nd-booking' ), $labels['qst'], nd_booking_format_percentage( $rates['qst'] ) ),
+                );
+        }
+
+        $total_tax = round( $lodging_amount + $gst_amount + $qst_amount, 2 );
+        $base_amount = round( $base_amount, 2 );
+        $total = round( $base_amount + $total_tax, 2 );
+
+        return array(
+                'base'      => $base_amount,
+                'taxes'     => $taxes,
+                'total_tax' => $total_tax,
+                'total'     => $total,
+        );
+
+}
+
+function nd_booking_calculate_tax_breakdown_from_total( $total_amount ) {
+
+        $total_amount = max( 0, floatval( $total_amount ) );
+
+        $rates = array(
+                'lodging' => floatval( get_option( 'nd_booking_lodging_tax_rate', 0 ) ),
+                'gst'     => floatval( get_option( 'nd_booking_gst_rate', 0 ) ),
+                'qst'     => floatval( get_option( 'nd_booking_qst_rate', 0 ) ),
+        );
+
+        $l = $rates['lodging'] / 100;
+        $g = $rates['gst'] / 100;
+        $q = $rates['qst'] / 100;
+
+        $denominator = 1 + $l + $g + $q + ( $g * $q );
+
+        if ( $denominator <= 0 ) {
+                $breakdown = nd_booking_calculate_tax_breakdown( $total_amount );
+                $breakdown['total'] = round( $total_amount, 2 );
+                $breakdown['total_tax'] = round( $breakdown['total'] - $breakdown['base'], 2 );
+
+                return $breakdown;
+        }
+
+        $base_amount = $total_amount / $denominator;
+        $breakdown = nd_booking_calculate_tax_breakdown( $base_amount );
+
+        $expected_total = round( $total_amount, 2 );
+        $difference = $expected_total - $breakdown['total'];
+
+        if ( abs( $difference ) >= 0.01 && ! empty( $breakdown['taxes'] ) ) {
+                $last_key = array_key_last( $breakdown['taxes'] );
+                $breakdown['taxes'][ $last_key ]['amount'] = round( $breakdown['taxes'][ $last_key ]['amount'] + $difference, 2 );
+        }
+
+        if ( ! empty( $breakdown['taxes'] ) ) {
+                $total_tax = 0.0;
+                foreach ( $breakdown['taxes'] as $tax ) {
+                        $total_tax += floatval( $tax['amount'] );
+                }
+                $breakdown['total_tax'] = round( $total_tax, 2 );
+        }
+
+        $breakdown['total'] = $expected_total;
+        $breakdown['base'] = round( $expected_total - $breakdown['total_tax'], 2 );
+
+        return $breakdown;
 
 }
 

--- a/public_html/wp-content/plugins/nd-booking/inc/shortcodes/final_price.js
+++ b/public_html/wp-content/plugins/nd-booking/inc/shortcodes/final_price.js
@@ -7,11 +7,7 @@ function nd_booking_final_price(){
   var nd_booking_booking_checkbox_services = jQuery( "#nd_booking_booking_checkbox_services").val();
   var nd_booking_booking_form_final_price = jQuery( "#nd_booking_booking_form_trip_price").val();
 
-  //START post method
   jQuery.get(
-    
-  
-    //ajax
     nd_booking_my_vars_final_price.nd_booking_ajaxurl_final_price,
     {
       action : 'nd_booking_final_price_php',
@@ -19,26 +15,90 @@ function nd_booking_final_price(){
       nd_booking_booking_form_final_price : nd_booking_booking_form_final_price,
       nd_booking_final_price_security : nd_booking_my_vars_final_price.nd_booking_ajaxnonce_final_price,
     },
-    //end ajax
+    null,
+    'json'
+  )
+  .done(function( response ) {
 
+    if ( response && response.success && response.data ) {
 
-    //START success
-    function( nd_booking_booking_result ) {
+      var data = response.data;
+      var currency = data.currency || '';
 
       jQuery( "#nd_booking_final_trip_price span" ).empty();
-      jQuery( "#nd_booking_final_trip_price span" ).text(nd_booking_booking_result);
-      jQuery( "#nd_booking_booking_form_final_price").val(nd_booking_booking_result);
+      jQuery( "#nd_booking_final_trip_price span" ).text( data.total_formatted );
+      jQuery( "#nd_booking_booking_form_final_price" ).val( data.total_raw );
 
-      jQuery( "#nd_booking_sorting_result_layer" ).remove(); 
+      if ( jQuery( "#nd_booking_booking_form_base_price" ).length ) {
+        jQuery( "#nd_booking_booking_form_base_price" ).val( data.base_raw );
+      }
+
+      nd_booking_update_tax_breakdown( data, currency );
 
     }
-    //END
 
-    
+  })
+  .always(function() {
 
-  );
-  //END
+    jQuery( "#nd_booking_sorting_result_layer" ).remove();
 
-  
+  });
+
+
 }
 //END function
+
+function nd_booking_update_tax_breakdown( data, currency ) {
+
+  var container = jQuery( ".nd_booking_tax_breakdown" );
+
+  if ( ! container.length ) {
+    return;
+  }
+
+  var subtotalLabel = data.subtotal_label || 'Subtotal';
+  var totalTaxLabel = data.total_tax_label || 'Total Tax';
+  var grandTotalLabel = data.grand_total_label || 'Grand Total';
+
+  var subtotalLine = container.find( '[data-tax-key="subtotal"]' );
+  subtotalLine.find( '.nd_booking_tax_label' ).text( subtotalLabel );
+  subtotalLine.find( '.nd_booking_tax_amount' ).text( data.base_formatted || data.base_raw || '0.00' );
+  subtotalLine.find( '.nd_booking_tax_currency' ).text( currency );
+  subtotalLine.show();
+
+  var handledKeys = {};
+  if ( Array.isArray( data.taxes ) ) {
+    for ( var i = 0; i < data.taxes.length; i++ ) {
+      var tax = data.taxes[i];
+      var key = tax.key;
+      handledKeys[key] = true;
+      var taxLine = container.find( '[data-tax-key="' + key + '"]' );
+      if ( taxLine.length ) {
+        taxLine.find( '.nd_booking_tax_label' ).text( tax.display_label || tax.label );
+        taxLine.find( '.nd_booking_tax_amount' ).text( tax.amount_formatted || tax.amount_raw || '0.00' );
+        taxLine.find( '.nd_booking_tax_currency' ).text( currency );
+        taxLine.show();
+      }
+    }
+  }
+
+  container.find( '[data-tax-key]' ).each(function() {
+    var key = jQuery( this ).data( 'tax-key' );
+    if ( key && key !== 'subtotal' && key !== 'total_tax' && key !== 'grand_total' && ! handledKeys[key] ) {
+      jQuery( this ).hide();
+    }
+  });
+
+  var totalTaxLine = container.find( '[data-tax-key="total_tax"]' );
+  totalTaxLine.find( '.nd_booking_tax_label' ).text( totalTaxLabel );
+  totalTaxLine.find( '.nd_booking_tax_amount' ).text( data.total_tax_formatted || data.total_tax_raw || '0.00' );
+  totalTaxLine.find( '.nd_booking_tax_currency' ).text( currency );
+  totalTaxLine.show();
+
+  var grandTotalLine = container.find( '[data-tax-key="grand_total"]' );
+  grandTotalLine.find( '.nd_booking_tax_label' ).text( grandTotalLabel );
+  grandTotalLine.find( '.nd_booking_tax_amount' ).text( data.total_formatted || data.total_raw || '0.00' );
+  grandTotalLine.find( '.nd_booking_tax_currency' ).text( currency );
+  grandTotalLine.show();
+
+}

--- a/public_html/wp-content/plugins/nd-booking/inc/shortcodes/include/booking/nd_booking_booking_left_content.php
+++ b/public_html/wp-content/plugins/nd-booking/inc/shortcodes/include/booking/nd_booking_booking_left_content.php
@@ -1,6 +1,42 @@
 <?php
 
 
+$nd_booking_tax_breakdown = nd_booking_calculate_tax_breakdown( $nd_booking_trip_price );
+$nd_booking_currency = nd_booking_get_currency();
+$nd_booking_initial_total_formatted = nd_booking_format_decimal( $nd_booking_tax_breakdown['total'] );
+$nd_booking_initial_subtotal_formatted = nd_booking_format_decimal( $nd_booking_tax_breakdown['base'] );
+$nd_booking_initial_tax_total_formatted = nd_booking_format_decimal( $nd_booking_tax_breakdown['total_tax'] );
+
+$nd_booking_known_tax_labels = array(
+    'lodging' => __( 'Lodging Tax', 'nd-booking' ),
+    'gst'     => __( 'GST', 'nd-booking' ),
+    'qst'     => __( 'QST', 'nd-booking' ),
+);
+
+$nd_booking_tax_lines = '<div class="nd_booking_section nd_booking_margin_top_20 nd_booking_tax_breakdown">';
+$nd_booking_tax_lines .= '<p class="nd_options_color_white nd_booking_font_size_13" data-tax-key="subtotal"><span class="nd_booking_tax_label">'.__( 'Subtotal', 'nd-booking' ).'</span> <span class="nd_booking_tax_amount">'.$nd_booking_initial_subtotal_formatted.'</span> <span class="nd_booking_tax_currency">'.$nd_booking_currency.'</span></p>';
+
+foreach ( $nd_booking_known_tax_labels as $nd_booking_tax_key => $nd_booking_tax_label ) {
+    $nd_booking_line_style = '';
+    if ( isset( $nd_booking_tax_breakdown['taxes'][ $nd_booking_tax_key ] ) ) {
+        $nd_booking_tax_rate = nd_booking_format_percentage( $nd_booking_tax_breakdown['taxes'][ $nd_booking_tax_key ]['rate'] );
+        $nd_booking_tax_amount_formatted = nd_booking_format_decimal( $nd_booking_tax_breakdown['taxes'][ $nd_booking_tax_key ]['amount'] );
+        $nd_booking_display_label = sprintf( __( '%1$s (%2$s%%)', 'nd-booking' ), $nd_booking_tax_breakdown['taxes'][ $nd_booking_tax_key ]['label'], $nd_booking_tax_rate );
+    } else {
+        $nd_booking_tax_amount_formatted = nd_booking_format_decimal( 0 );
+        $nd_booking_tax_rate = nd_booking_format_percentage( 0 );
+        $nd_booking_display_label = sprintf( __( '%1$s (%2$s%%)', 'nd-booking' ), $nd_booking_tax_label, $nd_booking_tax_rate );
+        $nd_booking_line_style = ' style="display:none;"';
+    }
+
+    $nd_booking_tax_lines .= '<p class="nd_options_color_white nd_booking_font_size_12" data-tax-key="'.$nd_booking_tax_key.'"'.$nd_booking_line_style.'><span class="nd_booking_tax_label">'.$nd_booking_display_label.'</span> <span class="nd_booking_tax_amount">'.$nd_booking_tax_amount_formatted.'</span> <span class="nd_booking_tax_currency">'.$nd_booking_currency.'</span></p>';
+}
+
+$nd_booking_tax_lines .= '<div class="nd_booking_section nd_booking_height_10"></div>';
+$nd_booking_tax_lines .= '<p class="nd_options_color_white nd_booking_font_size_13 nd_booking_font_weight_bold" data-tax-key="total_tax"><span class="nd_booking_tax_label">'.__( 'Total Tax', 'nd-booking' ).'</span> <span class="nd_booking_tax_amount">'.$nd_booking_initial_tax_total_formatted.'</span> <span class="nd_booking_tax_currency">'.$nd_booking_currency.'</span></p>';
+$nd_booking_tax_lines .= '<p class="nd_options_color_white nd_booking_font_size_14 nd_booking_font_weight_bolder" data-tax-key="grand_total"><span class="nd_booking_tax_label">'.__( 'Grand Total', 'nd-booking' ).'</span> <span class="nd_booking_tax_amount">'.$nd_booking_initial_total_formatted.'</span> <span class="nd_booking_tax_currency">'.$nd_booking_currency.'</span></p>';
+$nd_booking_tax_lines .= '</div>';
+
 $nd_booking_shortcode_left_content = '';
 
 //START price
@@ -134,10 +170,10 @@ $nd_booking_shortcode_left_content .= '
 
           <div class="nd_booking_display_inline_block ">
               <div id="nd_booking_final_trip_price_content" class="nd_booking_float_left nd_booking_text_align_right">
-                  <h1 id="nd_booking_final_trip_price" class="nd_options_color_white nd_booking_font_size_50"><span>'.$nd_booking_trip_price.'</span></h1>
+                  <h1 id="nd_booking_final_trip_price" class="nd_options_color_white nd_booking_font_size_50"><span>'.$nd_booking_initial_total_formatted.'</span></h1>
               </div>
               <div class="nd_booking_float_right nd_booking_text_align_left nd_booking_margin_left_10">
-                  <h5 class="nd_options_second_font nd_options_color_white nd_booking_margin_top_7 nd_booking_font_size_14 nd_booking_font_weight_lighter">'.nd_booking_get_currency().'<p></p>
+                  <h5 class="nd_options_second_font nd_options_color_white nd_booking_margin_top_7 nd_booking_font_size_14 nd_booking_font_weight_lighter">'.$nd_booking_currency.'<p></p>
                   <div class="nd_booking_section nd_booking_height_5"></div>
                   </h5><h3 class="nd_options_second_font nd_options_color_white nd_booking_font_size_14 nd_booking_letter_spacing_2 nd_booking_font_weight_lighter">/ '.__('TOTAL','nd-booking').'</h3>
               </div>
@@ -145,38 +181,9 @@ $nd_booking_shortcode_left_content .= '
 
       </div>
 
-  </div>
+  </div>'.$nd_booking_tax_lines.'
 
   <!--END black section-->';
-
-
-  $nd_booking_shortcode_left_content .= '
-  <div style="padding-top:20px;" class="nd_booking_section nd_booking_box_sizing_border_box nd_booking_padding_30">';
-
-    //city tax
-    if ( get_option('nd_booking_city_tax') != '' ) {
-      $nd_booking_shortcode_left_content .= '
-      <div class="nd_booking_section nd_booking_height_5"></div> 
-      <h6 class="nd_options_second_font nd_options_color_grey nd_booking_font_size_11 nd_booking_letter_spacing_2">
-        <span style="font-weight:400;" class="nd_options_color_greydark">'.__('NOT INCL :','nd-booking').'</span> '.get_option('nd_booking_city_tax').' '.nd_booking_get_currency().' '.__('CITY TAX ( person * night )','nd-booking').'
-      </h6>
-      <div class="nd_booking_section nd_booking_height_5"></div> ';
-    }
-
-    //vat
-    if ( get_option('nd_booking_vat') != '' ) {
-      $nd_booking_shortcode_left_content .= '
-      <div class="nd_booking_section nd_booking_height_5"></div> 
-      <h6 class="nd_options_second_font nd_options_color_grey nd_booking_font_size_11 nd_booking_letter_spacing_2">
-        <span style="font-weight:400;" class="nd_options_color_greydark">'.__('INCLUDED :','nd-booking').'</span> '.get_option('nd_booking_vat').' % '.__('VAT ALREADY APPLIED','nd-booking').'
-      </h6>
-      <div class="nd_booking_section nd_booking_height_5"></div> ';
-    }
-
-  $nd_booking_shortcode_left_content .= '
-  </div>';
-
-  
 
 
 $nd_booking_shortcode_left_content .= '

--- a/public_html/wp-content/plugins/nd-booking/inc/shortcodes/include/booking/nd_booking_booking_right_content.php
+++ b/public_html/wp-content/plugins/nd-booking/inc/shortcodes/include/booking/nd_booking_booking_right_content.php
@@ -1,6 +1,10 @@
 <?php
 
 
+$nd_booking_initial_breakdown = nd_booking_calculate_tax_breakdown( $nd_booking_trip_price );
+$nd_booking_initial_final_price = $nd_booking_initial_breakdown['total'];
+$nd_booking_initial_base_price = $nd_booking_initial_breakdown['base'];
+
 $nd_booking_shortcode_right_content = '
 
 <div class="nd_booking_section nd_booking_height_2 nd_booking_bg_grey"></div>
@@ -13,8 +17,9 @@ $nd_booking_shortcode_right_content = '
   <form method="post" enctype="multipart/form-data" action="'.nd_booking_checkout_page().'">
       
       <input type="hidden" id="nd_booking_form_booking_arrive" name="nd_booking_form_booking_arrive" value="1">
-      <input type="hidden" id="nd_booking_booking_form_final_price" name="nd_booking_booking_form_final_price" value="'.$nd_booking_trip_price.'">
-      <input type="hidden" id="nd_booking_booking_form_trip_price" name="nd_booking_booking_form_trip_price" value="'.$nd_booking_trip_price.'">
+      <input type="hidden" id="nd_booking_booking_form_final_price" name="nd_booking_booking_form_final_price" value="'.nd_booking_format_decimal( $nd_booking_initial_final_price ).'">
+      <input type="hidden" id="nd_booking_booking_form_base_price" name="nd_booking_booking_form_base_price" value="'.nd_booking_format_decimal( $nd_booking_initial_base_price ).'">
+      <input type="hidden" id="nd_booking_booking_form_trip_price" name="nd_booking_booking_form_trip_price" value="'.nd_booking_format_decimal( $nd_booking_trip_price ).'">
       <input type="hidden" id="nd_booking_booking_form_date_from" name="nd_booking_booking_form_date_from" value="'.$nd_booking_date_from.'">
       <input type="hidden" id="nd_booking_booking_form_date_to" name="nd_booking_booking_form_date_to" value="'.$nd_booking_date_tooo.'">
       <input type="hidden" id="nd_booking_booking_form_guests" name="nd_booking_booking_form_guests" value="'.$nd_booking_form_booking_guests.'">

--- a/public_html/wp-content/plugins/nd-booking/inc/shortcodes/include/checkout/nd_booking_checkout_payment_options.php
+++ b/public_html/wp-content/plugins/nd-booking/inc/shortcodes/include/checkout/nd_booking_checkout_payment_options.php
@@ -63,7 +63,8 @@ $nd_booking_shortcode_right_content .= '
                 <input type="hidden" id="nd_booking_checkout_form_date_from" name="nd_booking_checkout_form_date_from" value="'.$nd_booking_booking_form_date_from.'">
                 <input type="hidden" id="nd_booking_checkout_form_date_top" name="nd_booking_checkout_form_date_top" value="'.$nd_booking_booking_form_date_to.'">
                 <input type="hidden" id="nd_booking_checkout_form_guests" name="nd_booking_checkout_form_guests" value="'.$nd_booking_booking_form_guests.'">
-                <input type="hidden" id="nd_booking_checkout_form_final_price" name="nd_booking_checkout_form_final_price" value="'.$nd_booking_booking_form_final_price.'">
+                <input type="hidden" id="nd_booking_checkout_form_final_price" name="nd_booking_checkout_form_final_price" value="'.nd_booking_format_decimal( $nd_booking_booking_form_final_price ).'">
+                <input type="hidden" id="nd_booking_checkout_form_base_price" name="nd_booking_checkout_form_base_price" value="'.nd_booking_format_decimal( $nd_booking_tax_breakdown['base'] ).'">
                 <input type="hidden" id="nd_booking_checkout_form_post_id" name="nd_booking_checkout_form_post_id" value="'.$nd_booking_booking_form_post_id.'-'.$nd_booking_id_room.'">
                 <input type="hidden" id="nd_booking_checkout_form_post_title" name="nd_booking_checkout_form_post_title" value="'.$nd_booking_booking_form_post_title.'">
                 <input type="hidden" id="nd_booking_checkout_form_name" name="nd_booking_checkout_form_name" value="'.$nd_booking_booking_form_name.'">

--- a/public_html/wp-content/plugins/nd-booking/inc/shortcodes/include/checkout/nd_booking_checkout_right_content.php
+++ b/public_html/wp-content/plugins/nd-booking/inc/shortcodes/include/checkout/nd_booking_checkout_right_content.php
@@ -1,6 +1,45 @@
 <?php
 
 
+$nd_booking_checkout_tax_breakdown = isset( $nd_booking_tax_breakdown ) && is_array( $nd_booking_tax_breakdown )
+    ? $nd_booking_tax_breakdown
+    : nd_booking_calculate_tax_breakdown_from_total( $nd_booking_booking_form_final_price );
+$nd_booking_checkout_currency = nd_booking_get_currency();
+$nd_booking_checkout_subtotal_formatted = nd_booking_format_decimal( $nd_booking_checkout_tax_breakdown['base'] );
+$nd_booking_checkout_total_formatted = nd_booking_format_decimal( $nd_booking_checkout_tax_breakdown['total'] );
+$nd_booking_checkout_tax_total_formatted = nd_booking_format_decimal( $nd_booking_checkout_tax_breakdown['total_tax'] );
+
+$nd_booking_checkout_known_tax_labels = array(
+    'lodging' => __( 'Lodging Tax', 'nd-booking' ),
+    'gst'     => __( 'GST', 'nd-booking' ),
+    'qst'     => __( 'QST', 'nd-booking' ),
+);
+
+$nd_booking_checkout_tax_lines = '<div class="nd_booking_section nd_booking_height_10"></div>';
+$nd_booking_checkout_tax_lines .= '<div class="nd_booking_section nd_booking_tax_breakdown">';
+$nd_booking_checkout_tax_lines .= '<p class="nd_booking_font_size_13" data-tax-key="subtotal"><span class="nd_booking_tax_label">'.__( 'Subtotal', 'nd-booking' ).'</span>: <span class="nd_booking_tax_amount">'.$nd_booking_checkout_subtotal_formatted.'</span> <span class="nd_booking_tax_currency">'.$nd_booking_checkout_currency.'</span></p>';
+
+foreach ( $nd_booking_checkout_known_tax_labels as $nd_booking_tax_key => $nd_booking_tax_label ) {
+    $nd_booking_line_style = '';
+    if ( isset( $nd_booking_checkout_tax_breakdown['taxes'][ $nd_booking_tax_key ] ) ) {
+        $nd_booking_tax_rate = nd_booking_format_percentage( $nd_booking_checkout_tax_breakdown['taxes'][ $nd_booking_tax_key ]['rate'] );
+        $nd_booking_tax_amount_formatted = nd_booking_format_decimal( $nd_booking_checkout_tax_breakdown['taxes'][ $nd_booking_tax_key ]['amount'] );
+        $nd_booking_display_label = sprintf( __( '%1$s (%2$s%%)', 'nd-booking' ), $nd_booking_checkout_tax_breakdown['taxes'][ $nd_booking_tax_key ]['label'], $nd_booking_tax_rate );
+    } else {
+        $nd_booking_tax_amount_formatted = nd_booking_format_decimal( 0 );
+        $nd_booking_tax_rate = nd_booking_format_percentage( 0 );
+        $nd_booking_display_label = sprintf( __( '%1$s (%2$s%%)', 'nd-booking' ), $nd_booking_tax_label, $nd_booking_tax_rate );
+        $nd_booking_line_style = ' style="display:none;"';
+    }
+
+    $nd_booking_checkout_tax_lines .= '<p class="nd_booking_font_size_13" data-tax-key="'.$nd_booking_tax_key.'"'.$nd_booking_line_style.'><span class="nd_booking_tax_label">'.$nd_booking_display_label.'</span>: <span class="nd_booking_tax_amount">'.$nd_booking_tax_amount_formatted.'</span> <span class="nd_booking_tax_currency">'.$nd_booking_checkout_currency.'</span></p>';
+}
+
+$nd_booking_checkout_tax_lines .= '<div class="nd_booking_section nd_booking_height_5"></div>';
+$nd_booking_checkout_tax_lines .= '<p class="nd_booking_font_size_13 nd_booking_font_weight_bold" data-tax-key="total_tax"><span class="nd_booking_tax_label">'.__( 'Total Tax', 'nd-booking' ).'</span>: <span class="nd_booking_tax_amount">'.$nd_booking_checkout_tax_total_formatted.'</span> <span class="nd_booking_tax_currency">'.$nd_booking_checkout_currency.'</span></p>';
+$nd_booking_checkout_tax_lines .= '<p class="nd_booking_font_size_13 nd_booking_font_weight_bolder" data-tax-key="grand_total"><span class="nd_booking_tax_label">'.__( 'Grand Total', 'nd-booking' ).'</span>: <span class="nd_booking_tax_amount">'.$nd_booking_checkout_total_formatted.'</span> <span class="nd_booking_tax_currency">'.$nd_booking_checkout_currency.'</span></p>';
+$nd_booking_checkout_tax_lines .= '</div>';
+
 $nd_booking_shortcode_right_content = '';
 $nd_booking_shortcode_right_content .= '
 
@@ -112,26 +151,14 @@ $nd_booking_shortcode_right_content .= '
     ';
 
 
-    if ( get_option('nd_booking_city_tax') != '' OR get_option('nd_booking_vat') != '' ) {
+    $nd_booking_shortcode_right_content .= '
+    <div class="nd_booking_section nd_booking_height_30"></div>
 
-        $nd_booking_shortcode_right_content .= '
-        <div class="nd_booking_section nd_booking_height_30"></div>
-
-        <div class="nd_booking_width_100_percentage nd_booking_float_left nd_booking_box_sizing_border_ààbox ">
-            <p><span class="nd_options_color_greydark nd_booking_font_weight_bolder">'.__('Tax','nd-booking').' :</span></p>';
-
-            if ( get_option('nd_booking_city_tax') != '' ) {
-                $nd_booking_shortcode_right_content .= '<p>'.__('Included','nd-booking').'</span> '.$nd_booking_total_city_tax.' '.nd_booking_get_currency().' '.__('City Tax','nd-booking').'</p>';    
-            }
-            if ( get_option('nd_booking_vat') != '' ) {
-                $nd_booking_shortcode_right_content .= '<p>'.__('Included','nd-booking').' '.get_option('nd_booking_vat').' % '.__('VAT','nd-booking').'</p>';    
-            }
-        
-        $nd_booking_shortcode_right_content .= '
-        </div>
-        ';
-
-    } 
+    <div class="nd_booking_width_100_percentage nd_booking_float_left nd_booking_box_sizing_border_box ">
+        <p><span class="nd_options_color_greydark nd_booking_font_weight_bolder">'.__('Price Summary','nd-booking').' :</span></p>
+        '.$nd_booking_checkout_tax_lines.'
+    </div>
+    ';
 
 
 

--- a/public_html/wp-content/plugins/nd-booking/inc/shortcodes/include/order/nd_booking_order_left_content.php
+++ b/public_html/wp-content/plugins/nd-booking/inc/shortcodes/include/order/nd_booking_order_left_content.php
@@ -45,6 +45,42 @@ $nd_booking_new_date_to_format_l = date_i18n('l',strtotime($nd_booking_order_dat
 $nd_booking_new_date_to_format_Y = date_format($nd_booking_new_date_to, 'Y');
 
 
+$nd_booking_order_tax_breakdown = nd_booking_calculate_tax_breakdown_from_total( $nd_booking_order_final_trip_price );
+$nd_booking_order_currency = $nd_booking_order_paypal_currency;
+$nd_booking_order_total_formatted = nd_booking_format_decimal( $nd_booking_order_tax_breakdown['total'] );
+$nd_booking_order_subtotal_formatted = nd_booking_format_decimal( $nd_booking_order_tax_breakdown['base'] );
+$nd_booking_order_tax_total_formatted = nd_booking_format_decimal( $nd_booking_order_tax_breakdown['total_tax'] );
+
+$nd_booking_order_known_tax_labels = array(
+    'lodging' => __( 'Lodging Tax', 'nd-booking' ),
+    'gst'     => __( 'GST', 'nd-booking' ),
+    'qst'     => __( 'QST', 'nd-booking' ),
+);
+
+$nd_booking_order_tax_lines = '<div class="nd_booking_section nd_booking_margin_top_20 nd_booking_tax_breakdown">';
+$nd_booking_order_tax_lines .= '<p class="nd_options_color_white nd_booking_font_size_13" data-tax-key="subtotal"><span class="nd_booking_tax_label">'.__( 'Subtotal', 'nd-booking' ).'</span> <span class="nd_booking_tax_amount">'.$nd_booking_order_subtotal_formatted.'</span> <span class="nd_booking_tax_currency">'.$nd_booking_order_currency.'</span></p>';
+
+foreach ( $nd_booking_order_known_tax_labels as $nd_booking_tax_key => $nd_booking_tax_label ) {
+    $nd_booking_line_style = '';
+    if ( isset( $nd_booking_order_tax_breakdown['taxes'][ $nd_booking_tax_key ] ) ) {
+        $nd_booking_tax_rate = nd_booking_format_percentage( $nd_booking_order_tax_breakdown['taxes'][ $nd_booking_tax_key ]['rate'] );
+        $nd_booking_tax_amount_formatted = nd_booking_format_decimal( $nd_booking_order_tax_breakdown['taxes'][ $nd_booking_tax_key ]['amount'] );
+        $nd_booking_display_label = sprintf( __( '%1$s (%2$s%%)', 'nd-booking' ), $nd_booking_order_tax_breakdown['taxes'][ $nd_booking_tax_key ]['label'], $nd_booking_tax_rate );
+    } else {
+        $nd_booking_tax_amount_formatted = nd_booking_format_decimal( 0 );
+        $nd_booking_tax_rate = nd_booking_format_percentage( 0 );
+        $nd_booking_display_label = sprintf( __( '%1$s (%2$s%%)', 'nd-booking' ), $nd_booking_tax_label, $nd_booking_tax_rate );
+        $nd_booking_line_style = ' style="display:none;"';
+    }
+
+    $nd_booking_order_tax_lines .= '<p class="nd_options_color_white nd_booking_font_size_12" data-tax-key="'.$nd_booking_tax_key.'"'.$nd_booking_line_style.'><span class="nd_booking_tax_label">'.$nd_booking_display_label.'</span> <span class="nd_booking_tax_amount">'.$nd_booking_tax_amount_formatted.'</span> <span class="nd_booking_tax_currency">'.$nd_booking_order_currency.'</span></p>';
+}
+
+$nd_booking_order_tax_lines .= '<div class="nd_booking_section nd_booking_height_10"></div>';
+$nd_booking_order_tax_lines .= '<p class="nd_options_color_white nd_booking_font_size_13 nd_booking_font_weight_bold" data-tax-key="total_tax"><span class="nd_booking_tax_label">'.__( 'Total Tax', 'nd-booking' ).'</span> <span class="nd_booking_tax_amount">'.$nd_booking_order_tax_total_formatted.'</span> <span class="nd_booking_tax_currency">'.$nd_booking_order_currency.'</span></p>';
+$nd_booking_order_tax_lines .= '<p class="nd_options_color_white nd_booking_font_size_14 nd_booking_font_weight_bolder" data-tax-key="grand_total"><span class="nd_booking_tax_label">'.__( 'Grand Total', 'nd-booking' ).'</span> <span class="nd_booking_tax_amount">'.$nd_booking_order_total_formatted.'</span> <span class="nd_booking_tax_currency">'.$nd_booking_order_currency.'</span></p>';
+$nd_booking_order_tax_lines .= '</div>';
+
 $nd_booking_shortcode_left_content = '';
 $nd_booking_shortcode_left_content .= '
 
@@ -111,17 +147,17 @@ $nd_booking_shortcode_left_content .= '
 
               <div class="nd_booking_display_inline_block ">
                   <div id="nd_booking_final_trip_price_content" class="nd_booking_float_left nd_booking_text_align_right">
-                      <h1 id="nd_booking_final_trip_price" class="nd_options_color_white nd_booking_font_size_50"><span>'.$nd_booking_order_final_trip_price.'</span></h1>
+                      <h1 id="nd_booking_final_trip_price" class="nd_options_color_white nd_booking_font_size_50"><span>'.$nd_booking_order_total_formatted.'</span></h1>
                   </div>
                   <div class="nd_booking_float_right nd_booking_text_align_left nd_booking_margin_left_10">
-                      <h5 class="nd_options_second_font nd_options_color_white nd_booking_margin_top_7 nd_booking_font_size_14 nd_booking_font_weight_lighter">'.nd_booking_get_currency().'<p></p>
+                      <h5 class="nd_options_second_font nd_options_color_white nd_booking_margin_top_7 nd_booking_font_size_14 nd_booking_font_weight_lighter">'.$nd_booking_order_currency.'<p></p>
                       <div class="nd_booking_section nd_booking_height_5"></div>
                       </h5><h3 class="nd_options_second_font nd_options_color_white nd_booking_font_size_14 nd_booking_letter_spacing_2 nd_booking_font_weight_lighter">/ '.__('TOTAL','nd-booking').'</h3>
                   </div>
               </div>
 
           </div>
-  </div>
+  </div>'.$nd_booking_order_tax_lines.'
 
   <!--END black section-->
 

--- a/public_html/wp-content/plugins/nd-booking/inc/shortcodes/nd_booking_booking.php
+++ b/public_html/wp-content/plugins/nd-booking/inc/shortcodes/nd_booking_booking.php
@@ -251,36 +251,24 @@ function nd_booking_final_price_php() {
     check_ajax_referer( 'nd_booking_final_price_nonce', 'nd_booking_final_price_security' );
 
     //recover var
-    $nd_booking_booking_checkbox_services = sanitize_text_field($_GET['nd_booking_booking_checkbox_services']);
-    $nd_booking_booking_form_final_price = sanitize_text_field($_GET['nd_booking_booking_form_final_price']);
+    $nd_booking_booking_checkbox_services = isset( $_GET['nd_booking_booking_checkbox_services'] ) ? sanitize_text_field( wp_unslash( $_GET['nd_booking_booking_checkbox_services'] ) ) : '';
+    $nd_booking_booking_form_final_price = isset( $_GET['nd_booking_booking_form_final_price'] ) ? sanitize_text_field( wp_unslash( $_GET['nd_booking_booking_form_final_price'] ) ) : 0;
 
-    $nd_booking_booking_form_final_price = floatval($nd_booking_booking_form_final_price);
+    $nd_booking_booking_result = floatval( $nd_booking_booking_form_final_price );
 
-    //declare
-    $nd_booking_final_price_result = $nd_booking_booking_form_final_price;
-
-    $nd_booking_additional_services_value_array = explode(',', $nd_booking_booking_checkbox_services );
-    for ($nd_booking_i = 0; $nd_booking_i < count($nd_booking_additional_services_value_array)-1; $nd_booking_i++) {
-
-        $nd_booking_final_price_result = $nd_booking_final_price_result + floatval($nd_booking_additional_services_value_array[$nd_booking_i]);
-
+    $nd_booking_additional_services_value_array = array_filter( explode( ',', $nd_booking_booking_checkbox_services ) );
+    foreach ( $nd_booking_additional_services_value_array as $nd_booking_service_value ) {
+        $nd_booking_booking_result += floatval( $nd_booking_service_value );
     }
 
-    $nd_booking_booking_result = floatval($nd_booking_final_price_result);
+    $nd_booking_breakdown = nd_booking_calculate_tax_breakdown( $nd_booking_booking_result );
+    $nd_booking_currency = nd_booking_get_currency();
 
-    $nd_booking_lodging_rate = floatval( get_option( 'nd_booking_lodging_tax_rate', 0 ) );
-    $nd_booking_gst_rate = floatval( get_option( 'nd_booking_gst_rate', 0 ) );
-    $nd_booking_qst_rate = floatval( get_option( 'nd_booking_qst_rate', 0 ) );
-
-    $nd_booking_lodging_tax = $nd_booking_booking_result * $nd_booking_lodging_rate / 100;
-    $nd_booking_gst_tax = $nd_booking_booking_result * $nd_booking_gst_rate / 100;
-    $nd_booking_qst_tax = ( $nd_booking_booking_result + $nd_booking_gst_tax ) * $nd_booking_qst_rate / 100;
-
-    $nd_booking_lodging_tax = round( $nd_booking_lodging_tax, 2 );
-    $nd_booking_gst_tax = round( $nd_booking_gst_tax, 2 );
-    $nd_booking_qst_tax = round( $nd_booking_qst_tax, 2 );
-    $nd_booking_total_tax = round( $nd_booking_lodging_tax + $nd_booking_gst_tax + $nd_booking_qst_tax, 2 );
-    $nd_booking_final_with_tax = round( $nd_booking_booking_result + $nd_booking_total_tax, 2 );
+    $nd_booking_lodging_tax = isset( $nd_booking_breakdown['taxes']['lodging'] ) ? $nd_booking_breakdown['taxes']['lodging']['amount'] : 0.0;
+    $nd_booking_gst_tax = isset( $nd_booking_breakdown['taxes']['gst'] ) ? $nd_booking_breakdown['taxes']['gst']['amount'] : 0.0;
+    $nd_booking_qst_tax = isset( $nd_booking_breakdown['taxes']['qst'] ) ? $nd_booking_breakdown['taxes']['qst']['amount'] : 0.0;
+    $nd_booking_total_tax = $nd_booking_breakdown['total_tax'];
+    $nd_booking_final_with_tax = $nd_booking_breakdown['total'];
 
     if ( function_exists( 'session_status' ) ) {
         if ( PHP_SESSION_NONE === session_status() ) {
@@ -294,16 +282,43 @@ function nd_booking_final_price_php() {
         $_SESSION = array();
     }
 
-    $_SESSION['nd_booking_tax_base'] = $nd_booking_booking_result;
+    $_SESSION['nd_booking_tax_base'] = $nd_booking_breakdown['base'];
     $_SESSION['nd_booking_tax_lodging'] = $nd_booking_lodging_tax;
     $_SESSION['nd_booking_tax_gst'] = $nd_booking_gst_tax;
     $_SESSION['nd_booking_tax_qst'] = $nd_booking_qst_tax;
     $_SESSION['nd_booking_tax_total'] = $nd_booking_total_tax;
     $_SESSION['nd_booking_final_price'] = $nd_booking_final_with_tax;
 
-    echo esc_html( number_format( $nd_booking_final_with_tax, 2, '.', '' ) );
+    $nd_booking_response = array(
+        'currency'             => $nd_booking_currency,
+        'base_raw'             => nd_booking_format_decimal( $nd_booking_breakdown['base'] ),
+        'base_formatted'       => nd_booking_format_decimal( $nd_booking_breakdown['base'] ),
+        'total_tax_raw'        => nd_booking_format_decimal( $nd_booking_total_tax ),
+        'total_tax_formatted'  => nd_booking_format_decimal( $nd_booking_total_tax ),
+        'total_raw'            => nd_booking_format_decimal( $nd_booking_final_with_tax ),
+        'total_formatted'      => nd_booking_format_decimal( $nd_booking_final_with_tax ),
+        'taxes'                => array(),
+        'subtotal_label'       => __( 'Subtotal', 'nd-booking' ),
+        'total_tax_label'      => __( 'Total Tax', 'nd-booking' ),
+        'grand_total_label'    => __( 'Grand Total', 'nd-booking' ),
+    );
 
-    die();
+    $nd_booking_known_taxes = array( 'lodging', 'gst', 'qst' );
+    foreach ( $nd_booking_known_taxes as $nd_booking_tax_key ) {
+        if ( isset( $nd_booking_breakdown['taxes'][ $nd_booking_tax_key ] ) ) {
+            $nd_booking_tax_data = $nd_booking_breakdown['taxes'][ $nd_booking_tax_key ];
+            $nd_booking_response['taxes'][] = array(
+                'key'             => $nd_booking_tax_key,
+                'label'           => $nd_booking_tax_data['label'],
+                'display_label'   => $nd_booking_tax_data['display_label'],
+                'rate'            => nd_booking_format_percentage( $nd_booking_tax_data['rate'] ),
+                'amount_raw'      => nd_booking_format_decimal( $nd_booking_tax_data['amount'] ),
+                'amount_formatted'=> nd_booking_format_decimal( $nd_booking_tax_data['amount'] ),
+            );
+        }
+    }
+
+    wp_send_json_success( $nd_booking_response );
 
 }
 add_action( 'wp_ajax_nd_booking_final_price_php', 'nd_booking_final_price_php' );

--- a/public_html/wp-content/plugins/nd-booking/inc/shortcodes/nd_booking_checkout.php
+++ b/public_html/wp-content/plugins/nd-booking/inc/shortcodes/nd_booking_checkout.php
@@ -64,6 +64,7 @@ function nd_booking_shortcode_checkout() {
 
         //get value
         $nd_booking_booking_form_final_price = sanitize_text_field($_POST['nd_booking_booking_form_final_price']);
+        if( isset( $_POST['nd_booking_booking_form_base_price'] ) ) {  $nd_booking_booking_form_base_price = sanitize_text_field($_POST['nd_booking_booking_form_base_price']); }else{ $nd_booking_booking_form_base_price = '';}
         $nd_booking_booking_form_date_from = sanitize_text_field($_POST['nd_booking_booking_form_date_from']);
         $nd_booking_booking_form_date_to = sanitize_text_field($_POST['nd_booking_booking_form_date_to']);
         $nd_booking_booking_form_guests = sanitize_text_field($_POST['nd_booking_booking_form_guests']);
@@ -82,6 +83,9 @@ function nd_booking_shortcode_checkout() {
         $nd_booking_booking_form_post_id = sanitize_text_field($_POST['nd_booking_booking_form_post_id']);
         $nd_booking_booking_form_post_title = sanitize_text_field($_POST['nd_booking_booking_form_post_title']);
         $nd_booking_booking_form_services = sanitize_text_field($_POST['nd_booking_booking_checkbox_services_id']);
+
+        $nd_booking_booking_form_final_price = floatval( $nd_booking_booking_form_final_price );
+        $nd_booking_booking_form_base_price = floatval( $nd_booking_booking_form_base_price );
 
         if ( isset( $_POST['guest_id_number'] ) ) {
             $nd_booking_guest_id_number = sanitize_text_field( $_POST['guest_id_number'] );
@@ -146,12 +150,41 @@ function nd_booking_shortcode_checkout() {
         $nd_booking_booking_form_post_id = $nd_booking_ids_array[0];
         $nd_booking_id_room = $nd_booking_ids_array[1];
 
+        $nd_booking_tax_base_amount = $nd_booking_booking_form_base_price;
+        if ( $nd_booking_tax_base_amount <= 0 && isset( $_SESSION['nd_booking_tax_base'] ) ) {
+            $nd_booking_tax_base_amount = floatval( $_SESSION['nd_booking_tax_base'] );
+        }
+        if ( $nd_booking_tax_base_amount <= 0 && $nd_booking_total_tax_amount > 0 ) {
+            $nd_booking_tax_base_amount = round( $nd_booking_booking_form_final_price - $nd_booking_total_tax_amount, 2 );
+        }
+
+        if ( $nd_booking_tax_base_amount > 0 ) {
+            $nd_booking_tax_breakdown = nd_booking_calculate_tax_breakdown( $nd_booking_tax_base_amount );
+        } else {
+            $nd_booking_tax_breakdown = nd_booking_calculate_tax_breakdown_from_total( $nd_booking_booking_form_final_price );
+        }
+
+        $nd_booking_tax_base_amount = $nd_booking_tax_breakdown['base'];
+        $nd_booking_tax_lodging = isset( $nd_booking_tax_breakdown['taxes']['lodging'] ) ? $nd_booking_tax_breakdown['taxes']['lodging']['amount'] : 0.0;
+        $nd_booking_tax_gst = isset( $nd_booking_tax_breakdown['taxes']['gst'] ) ? $nd_booking_tax_breakdown['taxes']['gst']['amount'] : 0.0;
+        $nd_booking_tax_qst = isset( $nd_booking_tax_breakdown['taxes']['qst'] ) ? $nd_booking_tax_breakdown['taxes']['qst']['amount'] : 0.0;
+        $nd_booking_total_tax_amount = $nd_booking_tax_breakdown['total_tax'];
+        $nd_booking_booking_form_final_price = $nd_booking_tax_breakdown['total'];
+
+        if ( isset( $_SESSION ) && is_array( $_SESSION ) ) {
+            $_SESSION['nd_booking_tax_base'] = $nd_booking_tax_base_amount;
+            $_SESSION['nd_booking_tax_lodging'] = $nd_booking_tax_lodging;
+            $_SESSION['nd_booking_tax_gst'] = $nd_booking_tax_gst;
+            $_SESSION['nd_booking_tax_qst'] = $nd_booking_tax_qst;
+            $_SESSION['nd_booking_tax_total'] = $nd_booking_total_tax_amount;
+            $_SESSION['nd_booking_final_price'] = $nd_booking_booking_form_final_price;
+        }
+
         $nd_booking_total_city_tax = $nd_booking_total_tax_amount;
-        $nd_booking_booking_form_final_price += $nd_booking_total_tax_amount;
-    
-        include realpath(dirname( __FILE__ ).'/include/checkout/nd_booking_checkout_left_content.php'); 
-        include realpath(dirname( __FILE__ ).'/include/checkout/nd_booking_checkout_right_content.php'); 
-        include realpath(dirname( __FILE__ ).'/include/checkout/nd_booking_checkout_payment_options.php'); 
+
+        include realpath(dirname( __FILE__ ).'/include/checkout/nd_booking_checkout_left_content.php');
+        include realpath(dirname( __FILE__ ).'/include/checkout/nd_booking_checkout_right_content.php');
+        include realpath(dirname( __FILE__ ).'/include/checkout/nd_booking_checkout_payment_options.php');
         
         $nd_booking_shortcode_result .= '
 
@@ -198,6 +231,7 @@ function nd_booking_shortcode_checkout() {
             $nd_booking_booking_form_date_to = sanitize_text_field($_POST['nd_booking_checkout_form_date_top']);
             $nd_booking_booking_form_guests = sanitize_text_field($_POST['nd_booking_checkout_form_guests']);
             $nd_booking_booking_form_final_price = sanitize_text_field($_POST['nd_booking_checkout_form_final_price']);
+            if( isset( $_POST['nd_booking_checkout_form_base_price'] ) ) { $nd_booking_checkout_form_base_price = sanitize_text_field($_POST['nd_booking_checkout_form_base_price']); }else{ $nd_booking_checkout_form_base_price = ''; }
             $nd_booking_checkout_form_post_id = sanitize_text_field($_POST['nd_booking_checkout_form_post_id']);
             $nd_booking_checkout_form_post_title = sanitize_text_field($_POST['nd_booking_checkout_form_post_title']);
             $nd_booking_booking_form_name = sanitize_text_field($_POST['nd_booking_checkout_form_name']);
@@ -224,9 +258,42 @@ function nd_booking_shortcode_checkout() {
 
             //ids
             $nd_booking_checkout_form_post_id = sanitize_text_field($_POST['nd_booking_checkout_form_post_id']);
-            $nd_booking_ids_array = explode('-', $nd_booking_checkout_form_post_id ); 
+            $nd_booking_ids_array = explode('-', $nd_booking_checkout_form_post_id );
             $nd_booking_checkout_form_post_id = $nd_booking_ids_array[0];
             $nd_booking_id_room = $nd_booking_ids_array[1];
+
+            $nd_booking_booking_form_final_price = floatval( $nd_booking_booking_form_final_price );
+            $nd_booking_checkout_form_base_price = floatval( $nd_booking_checkout_form_base_price );
+
+            $nd_booking_tax_base_amount = $nd_booking_checkout_form_base_price;
+            if ( $nd_booking_tax_base_amount <= 0 && isset( $_SESSION['nd_booking_tax_base'] ) ) {
+                $nd_booking_tax_base_amount = floatval( $_SESSION['nd_booking_tax_base'] );
+            }
+            if ( $nd_booking_tax_base_amount <= 0 && $nd_booking_total_tax_amount > 0 ) {
+                $nd_booking_tax_base_amount = round( $nd_booking_booking_form_final_price - $nd_booking_total_tax_amount, 2 );
+            }
+
+            if ( $nd_booking_tax_base_amount > 0 ) {
+                $nd_booking_tax_breakdown = nd_booking_calculate_tax_breakdown( $nd_booking_tax_base_amount );
+            } else {
+                $nd_booking_tax_breakdown = nd_booking_calculate_tax_breakdown_from_total( $nd_booking_booking_form_final_price );
+            }
+
+            $nd_booking_tax_base_amount = $nd_booking_tax_breakdown['base'];
+            $nd_booking_tax_lodging = isset( $nd_booking_tax_breakdown['taxes']['lodging'] ) ? $nd_booking_tax_breakdown['taxes']['lodging']['amount'] : 0.0;
+            $nd_booking_tax_gst = isset( $nd_booking_tax_breakdown['taxes']['gst'] ) ? $nd_booking_tax_breakdown['taxes']['gst']['amount'] : 0.0;
+            $nd_booking_tax_qst = isset( $nd_booking_tax_breakdown['taxes']['qst'] ) ? $nd_booking_tax_breakdown['taxes']['qst']['amount'] : 0.0;
+            $nd_booking_total_tax_amount = $nd_booking_tax_breakdown['total_tax'];
+            $nd_booking_booking_form_final_price = $nd_booking_tax_breakdown['total'];
+
+            if ( isset( $_SESSION ) && is_array( $_SESSION ) ) {
+                $_SESSION['nd_booking_tax_base'] = $nd_booking_tax_base_amount;
+                $_SESSION['nd_booking_tax_lodging'] = $nd_booking_tax_lodging;
+                $_SESSION['nd_booking_tax_gst'] = $nd_booking_tax_gst;
+                $_SESSION['nd_booking_tax_qst'] = $nd_booking_tax_qst;
+                $_SESSION['nd_booking_tax_total'] = $nd_booking_total_tax_amount;
+                $_SESSION['nd_booking_final_price'] = $nd_booking_booking_form_final_price;
+            }
 
 
 


### PR DESCRIPTION
## Summary
- add reusable helpers to format and calculate tax breakdowns
- surface detailed tax lines plus grand totals on booking and checkout summaries and the order view
- update AJAX, frontend JS, and email templates to include tax amounts and percentages consistently

## Testing
- php -l public_html/wp-content/plugins/nd-booking/inc/functions/functions.php
- php -l public_html/wp-content/plugins/nd-booking/inc/shortcodes/include/booking/nd_booking_booking_left_content.php
- php -l public_html/wp-content/plugins/nd-booking/inc/shortcodes/include/booking/nd_booking_booking_right_content.php
- php -l public_html/wp-content/plugins/nd-booking/inc/shortcodes/include/checkout/nd_booking_checkout_payment_options.php
- php -l public_html/wp-content/plugins/nd-booking/inc/shortcodes/include/checkout/nd_booking_checkout_right_content.php
- php -l public_html/wp-content/plugins/nd-booking/inc/shortcodes/include/order/nd_booking_order_left_content.php
- php -l public_html/wp-content/plugins/nd-booking/inc/shortcodes/nd_booking_booking.php
- php -l public_html/wp-content/plugins/nd-booking/inc/shortcodes/nd_booking_checkout.php
- php -l public_html/wp-content/plugins/nd-booking/addons/message/index.php


------
https://chatgpt.com/codex/tasks/task_e_68c9c1f19cd08329a20b414bf1ca1865