### PR TITLE
Remove legacy city tax and VAT settings

### DIFF
--- a/public_html/wp-content/plugins/nd-booking/inc/admin/plugin-settings.php
+++ b/public_html/wp-content/plugins/nd-booking/inc/admin/plugin-settings.php
@@ -537,8 +537,6 @@ function nd_booking_add_paypal_settings(){
 
 
 function nd_booking_paypal_settings() {
-  register_setting( 'nd_booking_paypal_settings_group', 'nd_booking_city_tax' );
-  register_setting( 'nd_booking_paypal_settings_group', 'nd_booking_vat' );
   register_setting( 'nd_booking_paypal_settings_group', 'nd_booking_lodging_tax_rate' );
   register_setting( 'nd_booking_paypal_settings_group', 'nd_booking_gst_rate' );
   register_setting( 'nd_booking_paypal_settings_group', 'nd_booking_qst_rate' );
@@ -638,40 +636,6 @@ function nd_booking_paypal_page() {
         <div class="nd_booking_section nd_booking_height_1 nd_booking_background_color_E7E7E7 nd_booking_margin_top_10 nd_booking_margin_bottom_10"></div>
 
         
-
-        <!--START-->
-        <div class="nd_booking_section">
-          <div class="nd_booking_width_40_percentage nd_booking_padding_20 nd_booking_box_sizing_border_box nd_booking_float_left">
-            <h2 class="nd_booking_section nd_booking_margin_0"><?php _e('City Tax','nd-booking'); ?></h2>
-            <p class="nd_booking_color_666666 nd_booking_section nd_booking_margin_0 nd_booking_margin_top_10"><?php _e('Insert city tax value','nd-booking'); ?></p>
-          </div>
-          <div class="nd_booking_width_60_percentage nd_booking_padding_20 nd_booking_box_sizing_border_box nd_booking_float_left">
-            
-            <input class="regular-text nd_booking_width_100_percentage" type="text" name="nd_booking_city_tax" value="<?php echo esc_attr( get_option('nd_booking_city_tax') ); ?>" />
-            <p class="nd_booking_color_666666 nd_booking_section nd_booking_margin_0 nd_booking_margin_top_20"><?php _e('Insert your city tax value, only number ( not mandatory ), City tax is calculated per person per night.','nd-booking'); ?></p>
-
-          </div>
-        </div>
-        <!--END-->
-        <div class="nd_booking_section nd_booking_height_1 nd_booking_background_color_E7E7E7 nd_booking_margin_top_10 nd_booking_margin_bottom_10"></div>
-
-
-        <!--START-->
-        <div class="nd_booking_section">
-          <div class="nd_booking_width_40_percentage nd_booking_padding_20 nd_booking_box_sizing_border_box nd_booking_float_left">
-            <h2 class="nd_booking_section nd_booking_margin_0"><?php _e('VAT','nd-booking'); ?></h2>
-            <p class="nd_booking_color_666666 nd_booking_section nd_booking_margin_0 nd_booking_margin_top_10"><?php _e('Insert your country VAT','nd-booking'); ?></p>
-          </div>
-          <div class="nd_booking_width_60_percentage nd_booking_padding_20 nd_booking_box_sizing_border_box nd_booking_float_left">
-            
-            <input class="regular-text nd_booking_width_100_percentage" type="text" name="nd_booking_vat" value="<?php echo esc_attr( get_option('nd_booking_vat') ); ?>" />
-            <p class="nd_booking_color_666666 nd_booking_section nd_booking_margin_0 nd_booking_margin_top_20"><?php _e('Insert your country VAT value, only number ( not mandatory ).','nd-booking'); ?></p>
-
-          </div>
-        </div>
-        <!--END-->
-        <div class="nd_booking_section nd_booking_height_1 nd_booking_background_color_E7E7E7 nd_booking_margin_top_10 nd_booking_margin_bottom_10"></div>
-
 
         <!--START-->
         <div class="nd_booking_section">

--- a/public_html/wp-content/plugins/nd-booking/inc/shortcodes/nd_booking_checkout.php
+++ b/public_html/wp-content/plugins/nd-booking/inc/shortcodes/nd_booking_checkout.php
@@ -180,8 +180,6 @@ function nd_booking_shortcode_checkout() {
             $_SESSION['nd_booking_final_price'] = $nd_booking_booking_form_final_price;
         }
 
-        $nd_booking_total_city_tax = $nd_booking_total_tax_amount;
-
         include realpath(dirname( __FILE__ ).'/include/checkout/nd_booking_checkout_left_content.php');
         include realpath(dirname( __FILE__ ).'/include/checkout/nd_booking_checkout_right_content.php');
         include realpath(dirname( __FILE__ ).'/include/checkout/nd_booking_checkout_payment_options.php');

--- a/public_html/wp-content/plugins/wp-loft-booking-plugin/includes/admin/payment-settings.php
+++ b/public_html/wp-content/plugins/wp-loft-booking-plugin/includes/admin/payment-settings.php
@@ -18,8 +18,6 @@ function loft_booking_payment_settings_page() {
 function loft_booking_payment_settings() {
     // Save Settings if Form is Submitted
     if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['save_payment_settings'])) {
-        update_option('loft_city_tax', sanitize_text_field($_POST['city_tax']));
-        update_option('loft_vat', sanitize_text_field($_POST['vat']));
         update_option('stripe_publishable_key', sanitize_text_field($_POST['stripe_publishable_key']));
         update_option('stripe_secret_key', sanitize_text_field($_POST['stripe_secret_key']));
         update_option('stripe_checkout_message', sanitize_textarea_field($_POST['stripe_checkout_message']));
@@ -28,8 +26,6 @@ function loft_booking_payment_settings() {
     }
 
     // Fetch Existing Settings
-    $city_tax = get_option('loft_city_tax', '0');
-    $vat = get_option('loft_vat', '14.975');
     $stripe_publishable_key = get_option('stripe_publishable_key', '');
     $stripe_secret_key = get_option('stripe_secret_key', '');
     $stripe_checkout_message = get_option('stripe_checkout_message', 'Simple and safe. Make payments with any type of credit card.');
@@ -41,14 +37,6 @@ function loft_booking_payment_settings() {
         <h1>Payment Settings</h1>
         <form method="post">
             <table class="form-table">
-                <tr>
-                    <th scope="row"><label for="city_tax">City Tax (%)</label></th>
-                    <td><input type="number" id="city_tax" name="city_tax" value="<?php echo esc_attr($city_tax); ?>" step="0.01" /></td>
-                </tr>
-                <tr>
-                    <th scope="row"><label for="vat">VAT (%)</label></th>
-                    <td><input type="number" id="vat" name="vat" value="<?php echo esc_attr($vat); ?>" step="0.01" /></td>
-                </tr>
                 <tr>
                     <th scope="row"><label for="stripe_publishable_key">Stripe Publishable Key</label></th>
                     <td><input type="text" id="stripe_publishable_key" name="stripe_publishable_key" value="<?php echo esc_attr($stripe_publishable_key); ?>" /></td>

--- a/public_html/wp-content/themes/marina/import/demos-options.xml
+++ b/public_html/wp-content/themes/marina/import/demos-options.xml
@@ -415,14 +415,6 @@
 		<value>Default Template</value>
 		</option>
 		<option>
-		<name>nd_booking_city_tax</name>
-		<value>3</value>
-		</option>
-		<option>
-		<name>nd_booking_vat</name>
-		<value>22</value>
-		</option>
-		<option>
 		<name>nd_booking_paypal_developer</name>
 		<value>1</value>
 		</option>
@@ -999,14 +991,6 @@
 		<option>
 		<name>nd_booking_email_template</name>
 		<value>Default Template</value>
-		</option>
-		<option>
-		<name>nd_booking_city_tax</name>
-		<value>3</value>
-		</option>
-		<option>
-		<name>nd_booking_vat</name>
-		<value>22</value>
 		</option>
 		<option>
 		<name>nd_booking_paypal_developer</name>
@@ -1587,14 +1571,6 @@
 		<value>Default Template</value>
 		</option>
 		<option>
-		<name>nd_booking_city_tax</name>
-		<value>3</value>
-		</option>
-		<option>
-		<name>nd_booking_vat</name>
-		<value>22</value>
-		</option>
-		<option>
 		<name>nd_booking_paypal_developer</name>
 		<value>1</value>
 		</option>
@@ -2171,14 +2147,6 @@
 		<option>
 		<name>nd_booking_email_template</name>
 		<value>Default Template</value>
-		</option>
-		<option>
-		<name>nd_booking_city_tax</name>
-		<value>3</value>
-		</option>
-		<option>
-		<name>nd_booking_vat</name>
-		<value>22</value>
 		</option>
 		<option>
 		<name>nd_booking_paypal_developer</name>
@@ -2759,14 +2727,6 @@
 		<value>Default Template</value>
 		</option>
 		<option>
-		<name>nd_booking_city_tax</name>
-		<value>3</value>
-		</option>
-		<option>
-		<name>nd_booking_vat</name>
-		<value>22</value>
-		</option>
-		<option>
 		<name>nd_booking_paypal_developer</name>
 		<value>1</value>
 		</option>
@@ -3343,14 +3303,6 @@
 		<option>
 		<name>nd_booking_email_template</name>
 		<value>Default Template</value>
-		</option>
-		<option>
-		<name>nd_booking_city_tax</name>
-		<value>3</value>
-		</option>
-		<option>
-		<name>nd_booking_vat</name>
-		<value>22</value>
 		</option>
 		<option>
 		<name>nd_booking_paypal_developer</name>
@@ -3931,14 +3883,6 @@
 		<value>Default Template</value>
 		</option>
 		<option>
-		<name>nd_booking_city_tax</name>
-		<value>3</value>
-		</option>
-		<option>
-		<name>nd_booking_vat</name>
-		<value>22</value>
-		</option>
-		<option>
 		<name>nd_booking_paypal_developer</name>
 		<value>1</value>
 		</option>
@@ -4517,14 +4461,6 @@
 		<value>Default Template</value>
 		</option>
 		<option>
-		<name>nd_booking_city_tax</name>
-		<value>3</value>
-		</option>
-		<option>
-		<name>nd_booking_vat</name>
-		<value>22</value>
-		</option>
-		<option>
 		<name>nd_booking_paypal_developer</name>
 		<value>1</value>
 		</option>
@@ -5101,14 +5037,6 @@
 		<option>
 		<name>nd_booking_email_template</name>
 		<value>Default Template</value>
-		</option>
-		<option>
-		<name>nd_booking_city_tax</name>
-		<value>3</value>
-		</option>
-		<option>
-		<name>nd_booking_vat</name>
-		<value>22</value>
 		</option>
 		<option>
 		<name>nd_booking_paypal_developer</name>


### PR DESCRIPTION
## Summary
- remove the unused city tax and VAT settings from the ND Booking admin payment screen and demo data
- drop the dead checkout reference to the legacy city tax total so only current tax rates are tracked
- streamline the custom Loft payment settings page to only handle Stripe configuration fields

## Testing
- php -l public_html/wp-content/plugins/nd-booking/inc/admin/plugin-settings.php
- php -l public_html/wp-content/plugins/nd-booking/inc/shortcodes/nd_booking_checkout.php
- php -l public_html/wp-content/plugins/wp-loft-booking-plugin/includes/admin/payment-settings.php

------
https://chatgpt.com/codex/tasks/task_e_68c9d7fbb66083298ddf96909f79aa6d