### PR TITLE
Ensure default tax rates are applied when options unset

### DIFF
--- a/public_html/wp-content/plugins/nd-booking/inc/admin/plugin-settings.php
+++ b/public_html/wp-content/plugins/nd-booking/inc/admin/plugin-settings.php
@@ -645,7 +645,7 @@ function nd_booking_paypal_page() {
           </div>
           <div class="nd_booking_width_60_percentage nd_booking_padding_20 nd_booking_box_sizing_border_box nd_booking_float_left">
 
-            <input class="regular-text nd_booking_width_100_percentage" type="text" name="nd_booking_lodging_tax_rate" value="<?php echo esc_attr( get_option('nd_booking_lodging_tax_rate', '3.5') ); ?>" />
+            <input class="regular-text nd_booking_width_100_percentage" type="text" name="nd_booking_lodging_tax_rate" value="<?php echo esc_attr( get_option( 'nd_booking_lodging_tax_rate', nd_booking_get_tax_rate_default( 'lodging' ) ) ); ?>" />
             <p class="nd_booking_color_666666 nd_booking_section nd_booking_margin_0 nd_booking_margin_top_20"><?php _e('Enter the lodging tax rate percentage for accommodations. Default 3.5%.','nd-booking'); ?></p>
 
           </div>
@@ -662,7 +662,7 @@ function nd_booking_paypal_page() {
           </div>
           <div class="nd_booking_width_60_percentage nd_booking_padding_20 nd_booking_box_sizing_border_box nd_booking_float_left">
 
-            <input class="regular-text nd_booking_width_100_percentage" type="text" name="nd_booking_gst_rate" value="<?php echo esc_attr( get_option('nd_booking_gst_rate', '5') ); ?>" />
+            <input class="regular-text nd_booking_width_100_percentage" type="text" name="nd_booking_gst_rate" value="<?php echo esc_attr( get_option( 'nd_booking_gst_rate', nd_booking_get_tax_rate_default( 'gst' ) ) ); ?>" />
             <p class="nd_booking_color_666666 nd_booking_section nd_booking_margin_0 nd_booking_margin_top_20"><?php _e('Enter the GST rate applied to reservations. Default 5%.','nd-booking'); ?></p>
 
           </div>
@@ -679,7 +679,7 @@ function nd_booking_paypal_page() {
           </div>
           <div class="nd_booking_width_60_percentage nd_booking_padding_20 nd_booking_box_sizing_border_box nd_booking_float_left">
 
-            <input class="regular-text nd_booking_width_100_percentage" type="text" name="nd_booking_qst_rate" value="<?php echo esc_attr( get_option('nd_booking_qst_rate', '9.975') ); ?>" />
+            <input class="regular-text nd_booking_width_100_percentage" type="text" name="nd_booking_qst_rate" value="<?php echo esc_attr( get_option( 'nd_booking_qst_rate', nd_booking_get_tax_rate_default( 'qst' ) ) ); ?>" />
             <p class="nd_booking_color_666666 nd_booking_section nd_booking_margin_0 nd_booking_margin_top_20"><?php _e('Enter the QST percentage for applicable stays. Default 9.975%.','nd-booking'); ?></p>
 
           </div>

--- a/public_html/wp-content/plugins/nd-booking/inc/functions/functions.php
+++ b/public_html/wp-content/plugins/nd-booking/inc/functions/functions.php
@@ -797,14 +797,44 @@ function nd_booking_format_percentage( $rate ) {
 
 }
 
+function nd_booking_get_tax_rate_defaults() {
+
+        static $defaults = null;
+
+        if ( null === $defaults ) {
+                $defaults = array(
+                        'lodging' => 3.5,
+                        'gst'     => 5,
+                        'qst'     => 9.975,
+                );
+        }
+
+        return $defaults;
+
+}
+
+function nd_booking_get_tax_rate_default( $type ) {
+
+        $defaults = nd_booking_get_tax_rate_defaults();
+
+        if ( isset( $defaults[ $type ] ) ) {
+                return $defaults[ $type ];
+        }
+
+        return 0;
+
+}
+
 function nd_booking_calculate_tax_breakdown( $base_amount ) {
 
         $base_amount = max( 0, floatval( $base_amount ) );
 
+        $defaults = nd_booking_get_tax_rate_defaults();
+
         $rates = array(
-                'lodging' => floatval( get_option( 'nd_booking_lodging_tax_rate', 0 ) ),
-                'gst'     => floatval( get_option( 'nd_booking_gst_rate', 0 ) ),
-                'qst'     => floatval( get_option( 'nd_booking_qst_rate', 0 ) ),
+                'lodging' => floatval( get_option( 'nd_booking_lodging_tax_rate', $defaults['lodging'] ) ),
+                'gst'     => floatval( get_option( 'nd_booking_gst_rate', $defaults['gst'] ) ),
+                'qst'     => floatval( get_option( 'nd_booking_qst_rate', $defaults['qst'] ) ),
         );
 
         $labels = array(
@@ -865,10 +895,12 @@ function nd_booking_calculate_tax_breakdown_from_total( $total_amount ) {
 
         $total_amount = max( 0, floatval( $total_amount ) );
 
+        $defaults = nd_booking_get_tax_rate_defaults();
+
         $rates = array(
-                'lodging' => floatval( get_option( 'nd_booking_lodging_tax_rate', 0 ) ),
-                'gst'     => floatval( get_option( 'nd_booking_gst_rate', 0 ) ),
-                'qst'     => floatval( get_option( 'nd_booking_qst_rate', 0 ) ),
+                'lodging' => floatval( get_option( 'nd_booking_lodging_tax_rate', $defaults['lodging'] ) ),
+                'gst'     => floatval( get_option( 'nd_booking_gst_rate', $defaults['gst'] ) ),
+                'qst'     => floatval( get_option( 'nd_booking_qst_rate', $defaults['qst'] ) ),
         );
 
         $l = $rates['lodging'] / 100;


### PR DESCRIPTION
## Summary
- add helpers exposing the default lodging, GST, and QST tax rates
- ensure checkout tax breakdown calculations fall back to the default rates
- load the same defaults in the payment settings form so the UI and logic stay in sync

## Testing
- php -l public_html/wp-content/plugins/nd-booking/inc/functions/functions.php
- php -l public_html/wp-content/plugins/nd-booking/inc/admin/plugin-settings.php

------
https://chatgpt.com/codex/tasks/task_e_68c9de3a4be48329b067b92578d1c9fb