### PR TITLE
Ensure ND Booking stores decimal booking totals

### DIFF
--- a/public_html/wp-content/plugins/nd-booking/inc/functions/functions.php
+++ b/public_html/wp-content/plugins/nd-booking/inc/functions/functions.php
@@ -591,17 +591,19 @@ function nd_booking_add_booking_in_db(
 
 
 	//START add order if the plugin is not in dev mode
-	if ( get_option('nd_booking_plugin_dev_mode') == 1 ){
+        if ( get_option('nd_booking_plugin_dev_mode') == 1 ){
 
-		//dev mode active not insert in db
+                //dev mode active not insert in db
 
-	}else{
-		
+        }else{
 
-		if ( nd_booking_check_if_order_is_present($nd_booking_id_post,$nd_booking_date_from,$nd_booking_date_to,$nd_booking_paypal_email,$nd_booking_action_type) == 0 ) {
+                $nd_booking_final_trip_price = nd_booking_format_decimal( $nd_booking_final_trip_price );
 
-			global $wpdb;
-			$nd_booking_table_name = $wpdb->prefix . 'nd_booking_booking';
+
+                if ( nd_booking_check_if_order_is_present($nd_booking_id_post,$nd_booking_date_from,$nd_booking_date_to,$nd_booking_paypal_email,$nd_booking_action_type) == 0 ) {
+
+                        global $wpdb;
+                        $nd_booking_table_name = $wpdb->prefix . 'nd_booking_booking';
 
 
 			//START INSERT DB
@@ -631,13 +633,38 @@ function nd_booking_add_booking_in_db(
 				'user_arrival' => $nd_booking_user_arrival,
 				'user_coupon' => $nd_booking_user_coupon,
 				'paypal_payment_status' => $nd_booking_paypal_payment_status,
-				'paypal_currency' => $nd_booking_paypal_currency,
-				'paypal_tx' => $nd_booking_paypal_tx,
-				'action_type' => $nd_booking_action_type
+                                'paypal_currency' => $nd_booking_paypal_currency,
+                                'paypal_tx' => $nd_booking_paypal_tx,
+                                'action_type' => $nd_booking_action_type
 
-			)
+                        ),
+                        array(
+                                '%d',
+                                '%s',
+                                '%s',
+                                '%s',
+                                '%s',
+                                '%d',
+                                '%s',
+                                '%s',
+                                '%d',
+                                '%s',
+                                '%s',
+                                '%s',
+                                '%s',
+                                '%s',
+                                '%s',
+                                '%s',
+                                '%s',
+                                '%s',
+                                '%s',
+                                '%s',
+                                '%s',
+                                '%s',
+                                '%s'
+                        )
 
-			);
+                        );
 
 			if ($nd_booking_add_booking){
 

--- a/public_html/wp-content/plugins/nd-booking/nd-booking.php
+++ b/public_html/wp-content/plugins/nd-booking/nd-booking.php
@@ -21,13 +21,13 @@ add_action('plugins_loaded', 'nd_booking_load_textdomain');
 
 ///////////////////////////////////////////////////DB///////////////////////////////////////////////////////////////
 register_activation_hook( __FILE__, 'nd_booking_create_booking_db' );
-function nd_booking_create_booking_db()
-{
+
+function nd_booking_get_booking_table_schema() {
     global $wpdb;
 
     $nd_booking_table_name = $wpdb->prefix . 'nd_booking_booking';
 
-    $nd_booking_sql = "CREATE TABLE $nd_booking_table_name (
+    return "CREATE TABLE $nd_booking_table_name (
       id int(11) NOT NULL AUTO_INCREMENT,
       id_post int(11) NOT NULL,
       title_post varchar(255) NOT NULL,
@@ -35,7 +35,7 @@ function nd_booking_create_booking_db()
       date_from varchar(255) NOT NULL,
       date_to varchar(255) NOT NULL,
       guests int(11) NOT NULL,
-      final_trip_price int(11) NOT NULL,
+      final_trip_price decimal(12,2) NOT NULL,
       extra_services varchar(255) NOT NULL,
       id_user int(11) NOT NULL,
       user_first_name varchar(255) NOT NULL,
@@ -54,10 +54,38 @@ function nd_booking_create_booking_db()
       action_type varchar(255) NOT NULL,
       UNIQUE KEY id (id)
     );";
+}
+
+function nd_booking_create_booking_db() {
+    require_once( ABSPATH . 'wp-admin/includes/upgrade.php' );
+    dbDelta( nd_booking_get_booking_table_schema() );
+}
+
+function nd_booking_maybe_upgrade_booking_db() {
+    global $wpdb;
+
+    $nd_booking_table_name = $wpdb->prefix . 'nd_booking_booking';
+
+    $table_exists = $wpdb->get_var(
+        $wpdb->prepare( 'SHOW TABLES LIKE %s', $wpdb->esc_like( $nd_booking_table_name ) )
+    );
+
+    if ( $table_exists !== $nd_booking_table_name ) {
+        return;
+    }
+
+    $final_trip_price_column = $wpdb->get_row(
+        $wpdb->prepare( "SHOW COLUMNS FROM $nd_booking_table_name LIKE %s", 'final_trip_price' )
+    );
+
+    if ( empty( $final_trip_price_column ) || false !== stripos( $final_trip_price_column->Type, 'decimal' ) ) {
+        return;
+    }
 
     require_once( ABSPATH . 'wp-admin/includes/upgrade.php' );
-    dbDelta( $nd_booking_sql );
+    dbDelta( nd_booking_get_booking_table_schema() );
 }
+add_action( 'plugins_loaded', 'nd_booking_maybe_upgrade_booking_db' );
 
 
 


### PR DESCRIPTION
## Summary
- change the booking table schema to store `final_trip_price` as DECIMAL and add an upgrade routine that applies the change to existing installs
- reuse the schema builder for activation/upgrade and guard the upgrade by checking the current column definition
- normalize and format booking inserts with `nd_booking_format_decimal()` and explicit insert formats so cents are preserved

## Testing
- php -l public_html/wp-content/plugins/nd-booking/nd-booking.php
- php -l public_html/wp-content/plugins/nd-booking/inc/functions/functions.php

------
https://chatgpt.com/codex/tasks/task_e_68c9ebdd2e808329bb94084eaae95e96