### PR TITLE
Add tax breakdown to admin order edit summary

### DIFF
--- a/public_html/wp-content/plugins/nd-booking/inc/admin/orders/include/edit.php
+++ b/public_html/wp-content/plugins/nd-booking/inc/admin/orders/include/edit.php
@@ -376,9 +376,79 @@ if ( empty($nd_booking_orders) ) {
 
               }
 
-              //price room
-              $nd_booking_tot_room = $nd_booking_order->final_trip_price - $nd_booking_tot_services;
-              $nd_booking_price_room = $nd_booking_tot_room/$nd_booking_order->guests;
+              //price room and taxes
+              $nd_booking_tax_lodging_raw = get_post_meta( $nd_booking_order->id, 'nd_booking_tax_lodging', true );
+              $nd_booking_tax_gst_raw = get_post_meta( $nd_booking_order->id, 'nd_booking_tax_gst', true );
+              $nd_booking_tax_qst_raw = get_post_meta( $nd_booking_order->id, 'nd_booking_tax_qst', true );
+
+              $nd_booking_tax_lodging = max( 0, floatval( $nd_booking_tax_lodging_raw ) );
+              $nd_booking_tax_gst = max( 0, floatval( $nd_booking_tax_gst_raw ) );
+              $nd_booking_tax_qst = max( 0, floatval( $nd_booking_tax_qst_raw ) );
+
+              $nd_booking_total_tax = $nd_booking_tax_lodging + $nd_booking_tax_gst + $nd_booking_tax_qst;
+
+              $nd_booking_final_trip_price_amount = floatval( $nd_booking_order->final_trip_price );
+              $nd_booking_final_trip_price_display = number_format_i18n( $nd_booking_final_trip_price_amount, 2 );
+              $nd_booking_tot_services_amount = floatval( $nd_booking_tot_services );
+              $nd_booking_room_subtotal = $nd_booking_final_trip_price_amount - $nd_booking_tot_services_amount - $nd_booking_total_tax;
+              if ( $nd_booking_room_subtotal < 0 ) { $nd_booking_room_subtotal = 0; }
+
+              $nd_booking_total_guests = absint( $nd_booking_order->guests );
+              if ( $nd_booking_total_guests > 0 ) {
+                $nd_booking_price_room = $nd_booking_room_subtotal / $nd_booking_total_guests;
+              }else{
+                $nd_booking_price_room = 0;
+              }
+
+              $nd_booking_currency = nd_booking_get_currency();
+              $nd_booking_price_room_display = number_format_i18n( $nd_booking_price_room, 2 );
+              $nd_booking_room_subtotal_display = number_format_i18n( $nd_booking_room_subtotal, 2 );
+              $nd_booking_tax_lodging_display = number_format_i18n( $nd_booking_tax_lodging, 2 );
+              $nd_booking_tax_gst_display = number_format_i18n( $nd_booking_tax_gst, 2 );
+              $nd_booking_tax_qst_display = number_format_i18n( $nd_booking_tax_qst, 2 );
+              $nd_booking_total_tax_display = number_format_i18n( $nd_booking_total_tax, 2 );
+
+              $nd_booking_has_tax_values = false;
+              $nd_booking_tax_component_values = array(
+                array(
+                  'raw' => $nd_booking_tax_lodging_raw,
+                  'amount' => $nd_booking_tax_lodging,
+                  'display' => $nd_booking_tax_lodging_display,
+                  'label' => __( 'Lodging Tax', 'nd-booking' ),
+                ),
+                array(
+                  'raw' => $nd_booking_tax_gst_raw,
+                  'amount' => $nd_booking_tax_gst,
+                  'display' => $nd_booking_tax_gst_display,
+                  'label' => __( 'GST', 'nd-booking' ),
+                ),
+                array(
+                  'raw' => $nd_booking_tax_qst_raw,
+                  'amount' => $nd_booking_tax_qst,
+                  'display' => $nd_booking_tax_qst_display,
+                  'label' => __( 'QST', 'nd-booking' ),
+                ),
+              );
+
+              foreach ( $nd_booking_tax_component_values as $nd_booking_tax_component_value ) {
+                if ( '' !== $nd_booking_tax_component_value['raw'] && null !== $nd_booking_tax_component_value['raw'] ) {
+                  $nd_booking_has_tax_values = true;
+                  break;
+                }
+              }
+
+              $nd_booking_tax_rows_markup = '';
+              foreach ( $nd_booking_tax_component_values as $nd_booking_tax_component_value ) {
+                if ( $nd_booking_tax_component_value['amount'] > 0 || ( '' !== $nd_booking_tax_component_value['raw'] && null !== $nd_booking_tax_component_value['raw'] ) ) {
+                  $nd_booking_tax_rows_markup .= '
+                  <tr>
+                    <td style="width:70%;">'.$nd_booking_tax_component_value['label'].'</td>
+                    <td style="width:10%;" class="nd_booking_text_align_right"><p></p></td>
+                    <td style="width:10%;" class="nd_booking_text_align_right"><p></p></td>
+                    <td style="width:10%;" class="nd_booking_text_align_right"><p>'.$nd_booking_tax_component_value['display'].' '.$nd_booking_currency.'</p></td>
+                  </tr>';
+                }
+              }
 
 
               $nd_booking_result .= '
@@ -387,19 +457,41 @@ if ( empty($nd_booking_orders) ) {
                 <table class="nd_booking_section">
                   <tr>
                     <td style="width:70%;">
-                      <span style="text-transform: capitalize;">'.nd_booking_get_slug('singular').'</span>
+                      <span style="text-transform: capitalize;">'.nd_booking_get_slug('singular').'</span> '.__('Subtotal','nd-booking').'
                     </td>
-                    <td style="width:10%;" class="nd_booking_text_align_right"><p>'.$nd_booking_price_room.' '.nd_booking_get_currency().'</p></td>
-                    <td style="width:10%;" class="nd_booking_text_align_right"><p>'.$nd_booking_order->guests.'</p></td>
-                    <td style="width:10%;" class="nd_booking_text_align_right"><p>'.$nd_booking_tot_room.' '.nd_booking_get_currency().'</p></td>
+                    <td style="width:10%;" class="nd_booking_text_align_right"><p>'.$nd_booking_price_room_display.' '.$nd_booking_currency.'</p></td>
+                    <td style="width:10%;" class="nd_booking_text_align_right"><p>'.$nd_booking_total_guests.'</p></td>
+                    <td style="width:10%;" class="nd_booking_text_align_right"><p>'.$nd_booking_room_subtotal_display.' '.$nd_booking_currency.'</p></td>
                   </tr>
 
                 </table>
 
               </div>
 
+              ';
 
 
+              if ( $nd_booking_tax_rows_markup != '' || $nd_booking_total_tax > 0 || $nd_booking_has_tax_values ) {
+                $nd_booking_result .= '
+                <div style="border-top:4px double #eee;" class="nd_booking_width_100_percentage nd_booking_width_100_percentage_all_iphone nd_booking_float_left">
+
+                  <table class="nd_booking_section">'.$nd_booking_tax_rows_markup.'
+                    <tr>
+                      <td style="width:70%;">
+                        <strong>'.__('TOTAL TAX','nd-booking').'</strong>
+                      </td>
+                      <td style="width:10%;" class="nd_booking_text_align_right"><p></p></td>
+                      <td style="width:10%;" class="nd_booking_text_align_right"><p></p></td>
+                      <td style="width:10%;" class="nd_booking_text_align_right"><p><strong>'.$nd_booking_total_tax_display.' '.$nd_booking_currency.'</strong></p></td>
+                    </tr>
+                  </table>
+
+                </div>';
+              }
+
+
+
+              $nd_booking_result .= '
               <div style="border-top:4px double #eee;" class="nd_booking_width_100_percentage nd_booking_width_100_percentage_all_iphone nd_booking_float_left">
 
                 <table class="nd_booking_section">
@@ -415,8 +507,8 @@ if ( empty($nd_booking_orders) ) {
                       $nd_booking_result .= '**';
                     }
 
-                    $nd_booking_result .= ' 
-                    '.$nd_booking_order->final_trip_price.' '.nd_booking_get_currency().'</h2></td>
+                    $nd_booking_result .= '
+                    '.$nd_booking_final_trip_price_display.' '.$nd_booking_currency.'</h2></td>
                   </tr>
                 </table>
 
@@ -429,7 +521,7 @@ if ( empty($nd_booking_orders) ) {
                 if ( $nd_booking_order->user_coupon != '' ) {
                   $nd_booking_result .= '<p class="nd_booking_margin_0">** '.__('One coupon was applied, the original price was :','nd-booking').' '.nd_booking_get_price_before_coupon($nd_booking_order->user_coupon,$nd_booking_order->final_trip_price).' '.nd_booking_get_currency().'</p>';
                 }
-                
+
 
               $nd_booking_result .= '
               </div>


### PR DESCRIPTION
## Summary
- load stored lodging, GST, and QST amounts for each booking when building the admin price details table and derive a room subtotal before tax
- render rows for the room subtotal, individual tax components, and the total tax so the admin view mirrors the checkout breakdown while keeping totals formatted

## Testing
- php -l public_html/wp-content/plugins/nd-booking/inc/admin/orders/include/edit.php

------
https://chatgpt.com/codex/tasks/task_e_68c9f3d7e35883299e614e953a1bc0fd