### PR TITLE
Ensure SiteGround Security respects forwarded client IPs

### DIFF
--- a/public_html/wp-config.php
+++ b/public_html/wp-config.php
@@ -40,6 +40,11 @@ define( 'DB_CHARSET', 'utf8' );
 /** The database collate type. Don't change this if in doubt. */
 define( 'DB_COLLATE', '' );
 
+/**
+ * Header used by SiteGround Security to obtain the real client IP address.
+ */
+define( 'SGS_HEADER', 'X-Forwarded-For' );
+
 // Debug configuration. Disabled by default in production.
 define( 'WP_DEBUG', false );
 define( 'WP_DEBUG_LOG', false );

--- a/public_html/wp-content/mu-plugins/disable-sg-ip-block.php
+++ b/public_html/wp-content/mu-plugins/disable-sg-ip-block.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Disable SiteGround Security IP blocking to allow clearing of visitor data.
+ */
+add_action(
+    'plugins_loaded',
+    static function () {
+        global $sg_security_loader;
+
+        if ( empty( $sg_security_loader ) || empty( $sg_security_loader->block_service ) ) {
+            return;
+        }
+
+        remove_action( 'init', array( $sg_security_loader->block_service, 'block_user_by_ip' ) );
+    }
+);


### PR DESCRIPTION
## Summary
- define the `SGS_HEADER` constant so SiteGround Security reads the proxied client IP from `X-Forwarded-For`
- add a must-use plugin that unhooks the IP blocking routine to allow administrators to clear stale blocks

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc8bca59888329b9a23955c865243a