### PR TITLE
Reorder sync units flow to prioritise keychains

### DIFF
--- a/public_html/wp-content/plugins/wp-loft-booking-plugin/includes/ajax/ajax-handlers.php
+++ b/public_html/wp-content/plugins/wp-loft-booking-plugin/includes/ajax/ajax-handlers.php
@@ -228,25 +228,9 @@ function wp_loft_booking_sync_units_only() {
 
 
 function wp_loft_booking_sync_units() {
-    $messages       = [];
-    $tenant_result  = null;
+    $messages        = [];
+    $tenant_result   = null;
     $keychain_synced = null;
-
-    if (function_exists('wp_loft_booking_fetch_and_save_tenants')) {
-        $tenant_result = wp_loft_booking_fetch_and_save_tenants();
-
-        if (is_wp_error($tenant_result)) {
-            if (wp_doing_ajax()) {
-                wp_send_json_error($tenant_result->get_error_message());
-            }
-
-            return $tenant_result;
-        }
-
-        if (is_array($tenant_result) && !empty($tenant_result['message'])) {
-            $messages[] = $tenant_result['message'];
-        }
-    }
 
     if (function_exists('wp_loft_booking_sync_keychains')) {
         $keychain_result = wp_loft_booking_sync_keychains();
@@ -273,6 +257,22 @@ function wp_loft_booking_sync_units() {
 
         if ($keychain_synced) {
             $messages[] = '🔑 Keychains synced successfully.';
+        }
+    }
+
+    if (function_exists('wp_loft_booking_fetch_and_save_tenants')) {
+        $tenant_result = wp_loft_booking_fetch_and_save_tenants();
+
+        if (is_wp_error($tenant_result)) {
+            if (wp_doing_ajax()) {
+                wp_send_json_error($tenant_result->get_error_message());
+            }
+
+            return $tenant_result;
+        }
+
+        if (is_array($tenant_result) && !empty($tenant_result['message'])) {
+            $messages[] = $tenant_result['message'];
         }
     }
 


### PR DESCRIPTION
## Summary
- update the manual Sync Units workflow so keychains are refreshed before tenants and units
- ensure the combined sync still reports keychain and tenant messages in the correct order

## Testing
- php -l public_html/wp-content/plugins/wp-loft-booking-plugin/includes/ajax/ajax-handlers.php

------
https://chatgpt.com/codex/tasks/task_e_68ddd07694dc8329b48580822b97cb14