### PR TITLE
Ensure manual unit sync refreshes keychains first

### DIFF
--- a/public_html/wp-content/plugins/wp-loft-booking-plugin/includes/admin/lofts.php
+++ b/public_html/wp-content/plugins/wp-loft-booking-plugin/includes/admin/lofts.php
@@ -139,6 +139,7 @@ function wp_loft_booking_lofts_page() {
 }
 
 add_action('wp_ajax_wp_loft_booking_sync_units', 'wp_loft_booking_sync_units');
+add_action('wp_ajax_wplb_sync_units', 'wp_loft_booking_sync_units');
 
 /**
  * Display all LOFT units, marking as Occupied if there is


### PR DESCRIPTION
## Summary
- register the legacy `wplb_sync_units` AJAX action so it reuses the unified sync routine that refreshes keychains and tenants before units

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddef5ff4688329a6b321654dca036b