### PR TITLE
Relink ButterflyMX keychains after unit sync

### DIFF
--- a/public_html/wp-content/plugins/wp-loft-booking-plugin/includes/admin/keychains.php
+++ b/public_html/wp-content/plugins/wp-loft-booking-plugin/includes/admin/keychains.php
@@ -186,6 +186,18 @@ function keychains_page_function() {
 
 
 
+if (!function_exists('wp_loft_booking_normalize_loft_label')) {
+    function wp_loft_booking_normalize_loft_label($label) {
+        if (preg_match('/LOFTS?\s*-*\s*([0-9]+)/i', $label, $matches)) {
+            return 'LOFT' . $matches[1];
+        }
+
+        $normalized = strtoupper(preg_replace('/[^A-Z0-9]/', '', (string) $label));
+
+        return $normalized !== '' ? $normalized : null;
+    }
+}
+
 function wp_loft_booking_sync_keychains_only($keychains) {
     global $wpdb;
 
@@ -280,6 +292,59 @@ function wp_loft_booking_sync_keychains_only($keychains) {
     }
 
     return true;
+}
+
+function wp_loft_booking_relink_keychains_to_units() {
+    global $wpdb;
+
+    $keychains_table = $wpdb->prefix . 'loft_keychains';
+    $units_table     = $wpdb->prefix . 'loft_units';
+
+    $keychains = $wpdb->get_results("SELECT id, name, unit_id FROM {$keychains_table}");
+
+    if (empty($keychains)) {
+        return 0;
+    }
+
+    $updated = 0;
+
+    foreach ($keychains as $keychain) {
+        $normalized = wp_loft_booking_normalize_loft_label($keychain->name);
+
+        if (empty($normalized)) {
+            continue;
+        }
+
+        $unit_id = $wpdb->get_var($wpdb->prepare(
+            "SELECT id FROM {$units_table} WHERE REPLACE(UPPER(unit_name), ' ', '') LIKE %s LIMIT 1",
+            '%' . $normalized . '%'
+        ));
+
+        if (!$unit_id || intval($unit_id) === intval($keychain->unit_id)) {
+            continue;
+        }
+
+        $wpdb->update(
+            $keychains_table,
+            ['unit_id' => intval($unit_id)],
+            ['id' => intval($keychain->id)],
+            ['%d'],
+            ['%d']
+        );
+
+        if ($wpdb->last_error) {
+            error_log('❌ Failed to relink keychain ID ' . intval($keychain->id) . ': ' . $wpdb->last_error);
+            continue;
+        }
+
+        $updated++;
+    }
+
+    if ($updated > 0) {
+        error_log("🔗 Relinked {$updated} keychains to refreshed units.");
+    }
+
+    return $updated;
 }
 
 

--- a/public_html/wp-content/plugins/wp-loft-booking-plugin/includes/admin/lofts.php
+++ b/public_html/wp-content/plugins/wp-loft-booking-plugin/includes/admin/lofts.php
@@ -139,6 +139,7 @@ function wp_loft_booking_lofts_page() {
 }
 
 add_action('wp_ajax_wp_loft_booking_sync_units', 'wp_loft_booking_sync_units');
+add_action('wp_ajax_wplb_sync_units', 'wp_loft_booking_sync_units');
 
 /**
  * Display all LOFT units, marking as Occupied if there is

--- a/public_html/wp-content/plugins/wp-loft-booking-plugin/includes/ajax/ajax-handlers.php
+++ b/public_html/wp-content/plugins/wp-loft-booking-plugin/includes/ajax/ajax-handlers.php
@@ -228,9 +228,26 @@ function wp_loft_booking_sync_units_only() {
 
 
 function wp_loft_booking_sync_units() {
-    $messages        = [];
-    $tenant_result   = null;
-    $keychain_synced = null;
+    $messages           = [];
+    $tenant_result      = null;
+    $keychain_synced    = null;
+    $keychains_relinked = null;
+
+    if (function_exists('wp_loft_booking_fetch_and_save_tenants')) {
+        $tenant_result = wp_loft_booking_fetch_and_save_tenants();
+
+        if (is_wp_error($tenant_result)) {
+            if (wp_doing_ajax()) {
+                wp_send_json_error($tenant_result->get_error_message());
+            }
+
+            return $tenant_result;
+        }
+
+        if (is_array($tenant_result) && !empty($tenant_result['message'])) {
+            $messages[] = $tenant_result['message'];
+        }
+    }
 
     if (function_exists('wp_loft_booking_sync_keychains')) {
         $keychain_result = wp_loft_booking_sync_keychains();
@@ -260,22 +277,6 @@ function wp_loft_booking_sync_units() {
         }
     }
 
-    if (function_exists('wp_loft_booking_fetch_and_save_tenants')) {
-        $tenant_result = wp_loft_booking_fetch_and_save_tenants();
-
-        if (is_wp_error($tenant_result)) {
-            if (wp_doing_ajax()) {
-                wp_send_json_error($tenant_result->get_error_message());
-            }
-
-            return $tenant_result;
-        }
-
-        if (is_array($tenant_result) && !empty($tenant_result['message'])) {
-            $messages[] = $tenant_result['message'];
-        }
-    }
-
     $unit_result = wp_loft_booking_sync_units_only();
 
     if (is_wp_error($unit_result)) {
@@ -288,6 +289,25 @@ function wp_loft_booking_sync_units() {
 
     if (is_array($unit_result) && !empty($unit_result['message'])) {
         $messages[] = $unit_result['message'];
+    }
+
+    if (function_exists('wp_loft_booking_relink_keychains_to_units')) {
+        $keychains_relinked = wp_loft_booking_relink_keychains_to_units();
+
+        if ($keychains_relinked instanceof WP_Error) {
+            if (wp_doing_ajax()) {
+                wp_send_json_error($keychains_relinked->get_error_message());
+            }
+
+            return $keychains_relinked;
+        }
+
+        if (is_numeric($keychains_relinked) && $keychains_relinked > 0) {
+            $messages[] = sprintf(
+                _n('🔗 Re-linked %d keychain to refreshed units.', '🔗 Re-linked %d keychains to refreshed units.', (int) $keychains_relinked, 'wp-loft-booking'),
+                (int) $keychains_relinked
+            );
+        }
     }
 
     $message = trim(implode(' ', array_filter($messages)));
@@ -305,6 +325,7 @@ function wp_loft_booking_sync_units() {
         'message'          => $message,
         'tenants'          => $tenant_result,
         'keychains_synced' => $keychain_synced,
+        'keychains_relinked' => $keychains_relinked,
         'units'            => $unit_result,
     ];
 }


### PR DESCRIPTION
## Summary
- add a shared helper to normalize loft labels and use it to relink keychains to units after refreshing ButterflyMX data
- extend the unit sync workflow to remap keychains once units are repopulated so admin tables keep showing active keys

## Testing
- php -l public_html/wp-content/plugins/wp-loft-booking-plugin/includes/ajax/ajax-handlers.php
- php -l public_html/wp-content/plugins/wp-loft-booking-plugin/includes/admin/keychains.php

------
https://chatgpt.com/codex/tasks/task_e_68ddef5ff4688329a6b321654dca036b