### PR TITLE
Call keychain admin sync from cron

### DIFF
--- a/public_html/wp-content/plugins/wp-loft-booking-plugin/includes/ajax/ajax-handlers.php
+++ b/public_html/wp-content/plugins/wp-loft-booking-plugin/includes/ajax/ajax-handlers.php
@@ -249,10 +249,10 @@ function wp_loft_booking_sync_units() {
         }
     }
 
-    if (function_exists('wp_loft_booking_sync_keychains')) {
-        $keychain_result = wp_loft_booking_sync_keychains();
+    if (function_exists('wp_loft_booking_trigger_keychains_page_sync')) {
+        $keychain_result = wp_loft_booking_trigger_keychains_page_sync();
 
-        if (is_wp_error($keychain_result)) {
+        if ($keychain_result instanceof WP_Error) {
             if (wp_doing_ajax()) {
                 wp_send_json_error($keychain_result->get_error_message());
             }
@@ -260,20 +260,9 @@ function wp_loft_booking_sync_units() {
             return $keychain_result;
         }
 
-        if ($keychain_result === false) {
-            $error = new WP_Error('wp_loft_booking_keychain_failed', 'Failed to sync keychains.');
-
-            if (wp_doing_ajax()) {
-                wp_send_json_error($error->get_error_message());
-            }
-
-            return $error;
-        }
-
-        $keychain_synced = (bool) $keychain_result;
-
-        if ($keychain_synced) {
-            $messages[] = '🔑 Keychains synced successfully.';
+        if ($keychain_result) {
+            $keychain_synced = true;
+            $messages[]      = '🔑 Keychains synced successfully.';
         }
     }
 

--- a/public_html/wp-content/plugins/wp-loft-booking-plugin/includes/cron/cron-jobs.php
+++ b/public_html/wp-content/plugins/wp-loft-booking-plugin/includes/cron/cron-jobs.php
@@ -82,8 +82,14 @@ add_action('wp_loft_booking_cron_sync', function () {
             wp_loft_booking_run_safely('wp_loft_booking_fetch_and_save_tenants');
         }
 
-        if (function_exists('wp_loft_booking_sync_keychains')) {
-            wp_loft_booking_sync_keychains();
+        $keychain_result = function_exists('wp_loft_booking_trigger_keychains_page_sync')
+            ? wp_loft_booking_trigger_keychains_page_sync()
+            : false;
+
+        if ($keychain_result instanceof WP_Error) {
+            error_log('[WP Loft Booking] Cron keychain sync failed: ' . $keychain_result->get_error_message());
+        } elseif ($keychain_result) {
+            error_log('🔑 Cron: keychains synced successfully via keychains_page_function.');
         }
 
         if (function_exists('wp_loft_booking_sync_units')) {

--- a/public_html/wp-content/plugins/wp-loft-booking-plugin/wp-loft-booking-plugin.php
+++ b/public_html/wp-content/plugins/wp-loft-booking-plugin/wp-loft-booking-plugin.php
@@ -57,6 +57,49 @@ function wp_loft_booking_noop_die_handler() {
 function wp_loft_booking_noop_die( $message = '', $title = '', $args = array() ) {}
 
 /**
+ * Trigger the existing keychains admin page flow programmatically.
+ *
+ * @return bool|WP_Error True when the sync ran, false when unavailable, or WP_Error on failure.
+ */
+function wp_loft_booking_trigger_keychains_page_sync() {
+    if ( ! function_exists( 'keychains_page_function' ) ) {
+        return false;
+    }
+
+    $original_post     = isset( $_POST ) ? $_POST : null;
+    $original_ob_level = ob_get_level();
+
+    try {
+        $_POST = is_array( $original_post ) ? $original_post : array();
+        $_POST['sync_keychains'] = 1;
+
+        ob_start();
+        wp_loft_booking_run_safely( 'keychains_page_function' );
+        ob_end_clean();
+
+        return true;
+    } catch ( Exception $exception ) {
+        error_log( '[WP Loft Booking] keychains_page_function failed: ' . $exception->getMessage() );
+
+        return new WP_Error( 'keychain_sync_failed', $exception->getMessage() );
+    } catch ( Error $error ) {
+        error_log( '[WP Loft Booking] keychains_page_function caused a fatal error: ' . $error->getMessage() );
+
+        return new WP_Error( 'keychain_sync_failed', $error->getMessage() );
+    } finally {
+        if ( null === $original_post ) {
+            unset( $_POST );
+        } else {
+            $_POST = $original_post;
+        }
+
+        while ( ob_get_level() > $original_ob_level ) {
+            ob_end_clean();
+        }
+    }
+}
+
+/**
  * Sync tenants, keychains and units in sequence without exiting.
  */
 function wp_loft_booking_full_sync() {


### PR DESCRIPTION
## Summary
- add a reusable helper to safely trigger `keychains_page_function` programmatically
- use the helper from the AJAX unit sync flow and the cron fallback so both paths refresh keychains the same way before syncing units

## Testing
- php -l public_html/wp-content/plugins/wp-loft-booking-plugin/wp-loft-booking-plugin.php
- php -l public_html/wp-content/plugins/wp-loft-booking-plugin/includes/ajax/ajax-handlers.php
- php -l public_html/wp-content/plugins/wp-loft-booking-plugin/includes/cron/cron-jobs.php

------
https://chatgpt.com/codex/tasks/task_e_68de7015f4988329bedee1ba58feee7f