### PR TITLE
Force French mobile hero line break and enforce white/smaller styling

### DIFF
--- a/public_html/wp-content/plugins/loft1325-mobile-homepage/assets/css/mobile-home.css
+++ b/public_html/wp-content/plugins/loft1325-mobile-homepage/assets/css/mobile-home.css
@@ -257,13 +257,13 @@ body.loft1325-mobile-home-active .loft1325-mobile-home a {
 }
 
 .loft1325-mobile-home__hero-title {
-    font-size: clamp(1.85rem, 6vw, 2.25rem);
-    line-height: 1.22;
+    font-size: clamp(1.4rem, 6.5vw, 1.9rem);
+    line-height: 1.15;
     font-weight: 700;
     margin: 0;
     letter-spacing: 0.02em;
     text-wrap: balance;
-    color: #0f172a !important;
+    color: #ffffff !important;
     font-family: 'Playfair Display', serif;
 }
 

--- a/public_html/wp-content/plugins/loft1325-mobile-homepage/templates/mobile-front-page.php
+++ b/public_html/wp-content/plugins/loft1325-mobile-homepage/templates/mobile-front-page.php
@@ -27,6 +27,14 @@ $empty_rooms_text   = $plugin->localize_label( 'Aucun loft n’est actuellement 
 $price_label        = ( 'en' === $language ) ? 'From %1$s%2$s' : 'À partir de %1$s%2$s';
 $rating_label       = $plugin->localize_label( 'Note %s sur 5', 'Rating %s out of 5' );
 $per_night_label    = $plugin->localize_label( 'par nuit', 'per night' );
+$hero_title         = $plugin->get_string( 'hero_title' );
+$hero_title_html    = esc_html( $hero_title );
+
+if ( 'fr' === $language ) {
+    $hero_title_html = 'Experience Hoteliere<br>100% Virtuelle';
+} elseif ( false !== strpos( $hero_title, '100%' ) && false === strpos( $hero_title, "\n" ) ) {
+    $hero_title_html = preg_replace( '/\s*100%/u', '<br>100%', $hero_title_html, 1 );
+}
 
 if ( ! $rooms_archive ) {
     $rooms_archive = home_url( '/' );
@@ -63,6 +71,12 @@ body.loft1325-mobile-home-active #loft1325-mobile-homepage .loft1325-mobile-home
     gap: 0.75rem;
     margin-bottom: 1.75rem;
     text-align: left;
+}
+
+body.loft1325-mobile-home-active #loft1325-mobile-homepage .loft1325-mobile-home__hero-title {
+    color: #ffffff !important;
+    font-size: clamp(1.4rem, 6.5vw, 1.9rem) !important;
+    line-height: 1.15 !important;
 }
 
 body.loft1325-mobile-home-active #loft1325-mobile-homepage .loft1325-mobile-home__section-title {
@@ -286,7 +300,7 @@ body.loft1325-mobile-home-active #loft1325-mobile-homepage .loft1325-mobile-home
 
                 <div class="loft1325-mobile-home__hero-content loft1325-mobile-home__hero-content--after-search">
                     <span class="loft1325-mobile-home__hero-pill"><?php echo esc_html( $plugin->get_string( 'hero_tagline' ) ); ?></span>
-                    <h1 class="loft1325-mobile-home__hero-title"><?php echo esc_html( $plugin->get_string( 'hero_title' ) ); ?></h1>
+                    <h1 class="loft1325-mobile-home__hero-title"><?php echo wp_kses( $hero_title_html, array( 'br' => array() ) ); ?></h1>
                     <p class="loft1325-mobile-home__hero-text"><?php echo esc_html( $plugin->get_string( 'hero_description' ) ); ?></p>
                 </div>
 


### PR DESCRIPTION
### Motivation
- Ensure the French hero headline reads as two lines (`Experience Hoteliere` / `100% Virtuelle`) on narrow mobile screens and that the headline is forced to be white and smaller for consistent contrast and layout.
- Apply the change at the template level so the rendering is deterministic even when content or caching would otherwise prevent a visual update.

### Description
- Update `templates/mobile-front-page.php` to build `$hero_title_html` and hardcode `Experience Hoteliere<br>100% Virtuelle` when `'$language' === 'fr'`, falling back to the previous regex-based break insertion for other languages, and output it with `wp_kses` to allow the injected `<br>`.
- Add inline CSS overrides in the template (with `!important`) to force the hero title color to white and reduce font size/line-height on the mobile homepage via the selector `body.loft1325-mobile-home-active #loft1325-mobile-homepage .loft1325-mobile-home__hero-title`.
- Align the base stylesheet in `assets/css/mobile-home.css` by reducing the `.loft1325-mobile-home__hero-title` `font-size`/`line-height` and setting `color: #ffffff !important` to match the forced inline rules.

### Testing
- Ran the Playwright screenshot script to capture a mobile view, but the browser process crashed with a `TargetClosedError` so the visual artifact could not be produced. 
- No automated unit or integration tests were run for this UI/content change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697abb8cc88c8329bbfedbc087116fa7)